### PR TITLE
Fix flag icon persisting in HUD when the map changes

### DIFF
--- a/source/game/game.h
+++ b/source/game/game.h
@@ -547,6 +547,7 @@ struct gameent : dynent, gamestate
         frags = flags = deaths = points = 0;
         totaldamage = totalshots = 0;
         lives = 3;
+        holdingflag = 0;
         maxhealth = 100;
         shield = 0;
         lifesequence = -1;


### PR DESCRIPTION
The `holdingflag` field was not being reset upon map change, causing the flag icon to persist in the HUD if the player was holding the flag.