### PR TITLE
Bring back the minimap in CTF

### DIFF
--- a/config/glsl/hud.cfg
+++ b/config/glsl/hud.cfg
@@ -80,34 +80,32 @@ shader 0 "hudrgb" [
     }
 ]
 
-minimapshader = [
-    shader 0 "hudminimap" [
-        attribute vec4 vvertex, vcolor;
-        attribute vec2 vtexcoord0;
-        uniform mat4 hudmatrix;
-        varying vec2 texcoord0;
-        varying vec4 colorscale;
-        void main(void)
-        {
-            gl_Position = hudmatrix * vvertex;
-            texcoord0 = vtexcoord0; 
-            colorscale = vcolor;
-        }
-    ] [
-        uniform sampler2D tex0;
-        varying vec2 texcoord0;
-        varying vec4 colorscale;
-        fragdata(0) vec4 fragcolor;
-        void main(void)
-        {
-            vec4 color = colorscale * texture2D(tex0, texcoord0);
-            float y = dot(color.rgb, vec3(0.299f, 0.587f, 0.114f));
-            fragcolor.rgb = mix(color.rgb, vec3(y), 0.5);
-            fragcolor.a   = colorscale.a * @minimapalpha;
-        }
-    ]
+shader 0 "hudminimap" [
+    attribute vec4 vvertex, vcolor;
+    attribute vec2 vtexcoord0;
+    uniform mat4 hudmatrix;
+    varying vec2 texcoord0;
+    varying vec4 colorscale;
+    void main(void)
+    {
+        gl_Position = hudmatrix * vvertex;
+        texcoord0 = vtexcoord0; 
+        colorscale = vcolor;
+    }
+] [
+    uniform sampler2D tex0;
+    varying vec2 texcoord0;
+    varying vec4 colorscale;
+    uniform float minimapalpha;
+    fragdata(0) vec4 fragcolor;
+    void main(void)
+    {
+        vec4 color = colorscale * texture2D(tex0, texcoord0);
+        float y = dot(color.rgb, vec3(0.299f, 0.587f, 0.114f));
+        fragcolor.rgb = mix(color.rgb, vec3(y), 0.5);
+        fragcolor.a   = colorscale.a * minimapalpha;
+    }
 ]
-minimapshader
 
 shader 0 "hudnotexture" [
     attribute vec4 vvertex, vcolor;

--- a/config/glsl/hud.cfg
+++ b/config/glsl/hud.cfg
@@ -80,31 +80,34 @@ shader 0 "hudrgb" [
     }
 ]
 
-shader 0 "hudminimap" [
-    attribute vec4 vvertex, vcolor;
-    attribute vec2 vtexcoord0;
-    uniform mat4 hudmatrix;
-    varying vec2 texcoord0;
-    varying vec4 colorscale;
-    void main(void)
-    {
-        gl_Position = hudmatrix * vvertex;
-        texcoord0 = vtexcoord0; 
-        colorscale = vcolor;
-    }
-] [
-    uniform sampler2D tex0;
-    varying vec2 texcoord0;
-    varying vec4 colorscale;
-    fragdata(0) vec4 fragcolor;
-    void main(void)
-    {
-        vec4 color = colorscale * texture2D(tex0, texcoord0);
-        float y = dot(color.rgb, vec3(0.299f, 0.587f, 0.114f));
-        fragcolor.rgb = mix(color.rgb, vec3(y), 0.5);
-        fragcolor.a   = colorscale.a;
-    }
+minimapshader = [
+    shader 0 "hudminimap" [
+        attribute vec4 vvertex, vcolor;
+        attribute vec2 vtexcoord0;
+        uniform mat4 hudmatrix;
+        varying vec2 texcoord0;
+        varying vec4 colorscale;
+        void main(void)
+        {
+            gl_Position = hudmatrix * vvertex;
+            texcoord0 = vtexcoord0; 
+            colorscale = vcolor;
+        }
+    ] [
+        uniform sampler2D tex0;
+        varying vec2 texcoord0;
+        varying vec4 colorscale;
+        fragdata(0) vec4 fragcolor;
+        void main(void)
+        {
+            vec4 color = colorscale * texture2D(tex0, texcoord0);
+            float y = dot(color.rgb, vec3(0.299f, 0.587f, 0.114f));
+            fragcolor.rgb = mix(color.rgb, vec3(y), 0.5);
+            fragcolor.a   = colorscale.a * @minimapalpha;
+        }
+    ]
 ]
+minimapshader
 
 shader 0 "hudnotexture" [
     attribute vec4 vvertex, vcolor;

--- a/config/glsl/hud.cfg
+++ b/config/glsl/hud.cfg
@@ -80,6 +80,32 @@ shader 0 "hudrgb" [
     }
 ]
 
+shader 0 "hudminimap" [
+    attribute vec4 vvertex, vcolor;
+    attribute vec2 vtexcoord0;
+    uniform mat4 hudmatrix;
+    varying vec2 texcoord0;
+    varying vec4 colorscale;
+    void main(void)
+    {
+        gl_Position = hudmatrix * vvertex;
+        texcoord0 = vtexcoord0; 
+        colorscale = vcolor;
+    }
+] [
+    uniform sampler2D tex0;
+    varying vec2 texcoord0;
+    varying vec4 colorscale;
+    fragdata(0) vec4 fragcolor;
+    void main(void)
+    {
+        vec4 color = colorscale * texture2D(tex0, texcoord0);
+        float y = dot(color.rgb, vec3(0.299f, 0.587f, 0.114f));
+        fragcolor.rgb = mix(color.rgb, vec3(y), 0.5);
+        fragcolor.a   = colorscale.a;
+    }
+]
+
 shader 0 "hudnotexture" [
     attribute vec4 vvertex, vcolor;
     uniform mat4 hudmatrix;

--- a/config/ui/hud.cfg
+++ b/config/ui/hud.cfg
@@ -136,7 +136,7 @@ radar_icon = [
 	r_diry = (vec2rotatey $dirx $diry $getcamyaw)
     bx = (+f $arg7 (*f $MINIMAP_SIZE $r_dirx))
     by = (+f $arg8 (*f $MINIMAP_SIZE $r_diry))
-    uispace -1 -1 [ uioffset $bx $by [ uiFastImgRotation $arg9 "hud/" $arg5 "" $arg4 $arg6 ] ]
+    uispace -1 -1 [ uioffset $bx $by [ uiFastImgRotated $arg9 "hud/" $arg5 "" $arg4 $arg6 ] ]
 ]
 
 .playerhud = [

--- a/config/ui/hud.cfg
+++ b/config/ui/hud.cfg
@@ -167,8 +167,8 @@ radar_icon = [
 				cteam = (getclientteam $getfollow)
 			] [ cteam = $getteam ]
 
-			uiminimap $getcamx $getcamy $getcamyaw $MINIMAP_SIZE    // minimap background
-			uiFastImg "" "hud/" "radar" "" $MINIMAP_SIZE            // minimap border
+			uiminimap $getcamx $getcamy $getcamyaw $MINIMAP_SIZE 16    // minimap background
+			uiFastImg "" "hud/" "radar" "" $MINIMAP_SIZE               // minimap border
 			
 			// flag bases
 			loop i $numflags [

--- a/config/ui/hud.cfg
+++ b/config/ui/hud.cfg
@@ -111,6 +111,42 @@ newui "hud" [
     ]
 ]
 
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//  MINIMAP UTILITIES                                                                                       //
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+MINIMAP_SIZE = 0.25
+
+// vector functions for minimap
+vec2magnitude = [ result (sqrt (+f (*f (at $arg1 0) (at $arg1 0)) (*f (at $arg1 1) (at $arg1 1)))) ]
+vec2sub = [ result (concat (-f (at $arg1 0) (at $arg2 0)) (-f (at $arg1 1) (at $arg2 1))) ] // v1 v2
+vec2scale = [ result (concat (*f $arg1 (at $arg2 0)) (*f $arg1 (at $arg2 1)))] // lambda vec
+vec2rotate = [ // vec angle
+    local c s x y
+    c = (cos $arg2)
+    s = (sin $arg2)
+    x = (-f (*f $c (at $arg1 0)) (*f $s (at $arg1 1)))
+    y = (+f (*f $c (at $arg1 1)) (*f $s (at $arg1 0)))
+    result (concat $x $y)
+]
+
+// o p o_yaw p_yaw folder icon scale=0.016 offset mad=""
+radar_icon = [
+    local dir dist bx by
+    if $arg7 [] [ arg7 = 0.016 ]
+	if $arg8 [] [ arg8 = "0 0" ]
+	if $arg9 [] [ arg9 = "" ]
+    dir = (vec2scale (divf 1 $calcradarscale) (vec2sub $arg1 $arg2))
+    dist = (vec2magnitude $dir)
+    if (>=f $dist 0.84) [
+        dir = (vec2scale (divf 0.84 $dist) $dir)
+    ]
+    dir = (vec2rotate $dir (* -1 $arg3))
+    bx = (+f (at $arg8 0) (*f $MINIMAP_SIZE (at $dir 0)))
+    by = (+f (at $arg8 1) (*f $MINIMAP_SIZE (at $dir 1)))
+    uioffset $bx $by [ uiFastImgRotation $arg9 $arg5 $arg6 "" $arg4 $arg7 ]
+]
+
 .playerhud = [
     if (uivisible "scoreboard") [ hideui "scoreboard" ]
     local x cn
@@ -128,6 +164,52 @@ newui "hud" [
         ] ; uialign- 1 1
     ] [ cn = $getclientnum ]
 
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//  MINIMAP DISPLAY GROUP                                                                                   //
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	if (&& $showminimap [m_ctf $getmode]) [
+		uispace $uiPad:L $uiPad:L [
+			local t o yaw
+			o = $getcampos
+			yaw = $getcamyaw
+			t = (? $isspectator (? (! (isspectator $getfollow)) (getclientteam $getfollow) $getteam) $getteam)
+			uiminimap (at $o 0) (at $o 1) $yaw $MINIMAP_SIZE        // minimap background
+			uiFastImg "" "hud/" "radar" "" $MINIMAP_SIZE            // minimap border
+			// flag bases
+			loop i $numflags [
+				radar_icon $o (flagbase $i) $yaw 0 "hud/" (+s "blip_" (? (= (flagteam $i) 1) "blue" "red"))
+			]
+			// players
+			looplist cn (listclients 1 1) [
+				if (&& [! (isspectator $cn)] [= $t (getclientteam $cn)] [!=s $cn (? (isspectator $getclientnum) $getfollow $getclientnum)] [! (getclientflag $cn)]) [
+					if $radarteammates [
+						if (isdead $cn) [
+							radar_icon $o (getclientpos $cn) $yaw 0 "hud/" (+s "blip_" (? (= (getclientteam $cn) 1) "blue" "red") "_dead")
+						] [
+							radar_icon $o (getclientpos $cn) $yaw (- $yaw (getclientyaw $cn)) "hud/" (+s "blip_" (? (= (getclientteam $cn) 1) "blue" "red") "_alive")
+						]
+					]
+				]
+			]
+			loop i $numflags [
+				case (flagstate $i) 0 [
+					// flag is at base
+					radar_icon $o (flagbase $i) $yaw 0 "hud/" (+s "blip_" (? (= (flagteam $i) 1) "blue" "red") "_flag") 0.0225 "0.018 -0.018"
+				] 1 [
+					// a player has the flag
+					if (< (mod $getmillis 1000) 500) [
+						radar_icon $o (getclientpos (flagowner $i)) $yaw 0 "hud/" (+s "blip_" (? (= (flagteam $i) 1) "blue" "red") "_flag") 0.0225 "0.018 -0.018"
+					]
+				] 2 [
+					// flag is dropped somewhere
+					if (&& [< (mod $getmillis 300) 150] [>= (at (flagdroploc $i) 0) 0]) [
+						radar_icon $o (flagdroploc $i) $yaw 0 "hud/" (+s "blip_" (? (= (flagteam $i) 1) "blue" "red") "_flag") 0.0225 "0.018 -0.018"
+					]
+				]
+			]
+		] ; uialign- 1 -1
+	]
+
     x = (maxf 0 (-f $uiaspect $uiWideHUD))
     if (>f $x 0) [ x = (*f $x 0.5) ]
 
@@ -138,6 +220,9 @@ newui "hud" [
     uispace $uiPad:L $uiPad:L [
         uivlist 0 [
             local i timestamp
+			if (&& $showminimap [m_ctf $getmode]) [
+				uifill 0 (+f $MINIMAP_SIZE $uiPad:L)
+			]
             looplistrev n $fragQueue [
                 case $i 0 [ timestamp = $n ] 1 [
                     do [ .killfeed.row @n ]

--- a/config/ui/hud.cfg
+++ b/config/ui/hud.cfg
@@ -121,16 +121,16 @@ MINIMAP_SIZE = 0.25
 vec2rotatex = [+f (*f (cos $arg3) $arg1) (*f (sin $arg3) $arg2)] // X cos(@) + Y sin(@)
 vec2rotatey = [-f (*f (cos $arg3) $arg2) (*f (sin $arg3) $arg1)] // Y cos(@) - X sin(@)
 
-// x y z angle icon scale=0.016 offsetx offsety mad
+// x y z angle icon scale=0.014 offsetx offsety mad
 radar_icon = [
     local dirx diry dist r_dirx r_diry bx by
-    if $arg6 [] [ arg6 = 0.016 ]
+    if $arg6 [] [ arg6 = 0.014 ]
 	dirx = (*f (divf 1 $calcradarscale) (-f $getcamx $arg1))
 	diry = (*f (divf 1 $calcradarscale) (-f $getcamy $arg2))
 	dist = (sqrt (+f (*f $dirx $dirx) (*f $diry $diry)))
-    if (>=f $dist 0.84) [
-		dirx = (*f (divf 0.84 $dist) $dirx)
-		diry = (*f (divf 0.84 $dist) $diry)
+    if (>=f $dist 0.85) [
+		dirx = (*f (divf 0.85 $dist) $dirx)
+		diry = (*f (divf 0.85 $dist) $diry)
     ]
 	r_dirx = (vec2rotatex $dirx $diry $getcamyaw)
 	r_diry = (vec2rotatey $dirx $diry $getcamyaw)
@@ -172,7 +172,7 @@ radar_icon = [
 			
 			// flag bases
 			loop i $numflags [
-				do [ radar_icon @(flagbase $i) 0 (+s "blip_" (? (= (flagteam $i) 1) "blue" "red")) ]
+				do [ radar_icon @(flagbase $i) 0 (+s "blip_" (? (= (flagteam $i) 1) "blue" "red")) 0.01 ]
 			]
 			
 			// players
@@ -190,16 +190,16 @@ radar_icon = [
 			loop i $numflags [
 				case (flagstate $i) 0 [
 					// flag is at base
-					do [ radar_icon @(flagbase $i) 0 (+s "blip_" (? (= (flagteam $i) 1) "blue" "red") "_flag") 0.0225 0.018 -0.018 ]
+					do [ radar_icon @(flagbase $i) 0 (+s "blip_" (? (= (flagteam $i) 1) "blue" "red") "_flag") 0.02 0.017 -0.017 ]
 				] 1 [
 					// a player has the flag
 					if (< (mod $getmillis 1000) 500) [
-						do [ radar_icon @(getclientpos (flagowner $i)) 0 (+s "blip_" (? (= (flagteam $i) 1) "blue" "red") "_flag") 0.0225 0.018 -0.018 ]
+						do [ radar_icon @(getclientpos (flagowner $i)) 0 (+s "blip_" (? (= (flagteam $i) 1) "blue" "red") "_flag") 0.02 0.017 -0.017 ]
 					]
 				] 2 [
 					// flag is dropped somewhere
 					if (< (mod $getmillis 300) 150) [
-						do [ radar_icon @(flagdroploc $i) 0 (+s "blip_" (? (= (flagteam $i) 1) "blue" "red") "_flag") 0.0225 0.018 -0.018 ]
+						do [ radar_icon @(flagdroploc $i) 0 (+s "blip_" (? (= (flagteam $i) 1) "blue" "red") "_flag") 0.02 0.017 -0.017 ]
 					]
 				] // 3 - flag fell under the map, don't show icon
 			]
@@ -245,9 +245,10 @@ radar_icon = [
 .resourcehud = [
     uihlist 0 [
         // resource (shield/health) display group
-        uivlist $uiPad:3XL [
+        uivlist 0 [
             if (getclientshield $cn) [
                 .bar.shield $uiPad:D5XL (getclientshield $cn) 200 shield
+            	uifill 0 $uiPad:XL
             ]
             .bar.health $uiPad:D6XL (getclienthealth $cn) (? $m_insta 1 100) health
         ] ; uialign- 0 1

--- a/config/ui/hud.cfg
+++ b/config/ui/hud.cfg
@@ -168,7 +168,7 @@ radar_icon = [
 			] [ cteam = $getteam ]
 
 			uiminimap $getcamx $getcamy $getcamyaw $MINIMAP_SIZE 16    // minimap background
-			uiFastImg "" "hud/" "radar" "" $MINIMAP_SIZE               // minimap border
+			uiFastImg "" "hud/" "radar" "" (+f $MINIMAP_SIZE 0.005)    // minimap border
 			
 			// flag bases
 			loop i $numflags [

--- a/config/ui/hud.cfg
+++ b/config/ui/hud.cfg
@@ -117,34 +117,26 @@ newui "hud" [
 
 MINIMAP_SIZE = 0.25
 
-// vector functions for minimap
-vec2magnitude = [ result (sqrt (+f (*f (at $arg1 0) (at $arg1 0)) (*f (at $arg1 1) (at $arg1 1)))) ]
-vec2sub = [ result (concat (-f (at $arg1 0) (at $arg2 0)) (-f (at $arg1 1) (at $arg2 1))) ] // v1 v2
-vec2scale = [ result (concat (*f $arg1 (at $arg2 0)) (*f $arg1 (at $arg2 1)))] // lambda vec
-vec2rotate = [ // vec angle
-    local c s x y
-    c = (cos $arg2)
-    s = (sin $arg2)
-    x = (-f (*f $c (at $arg1 0)) (*f $s (at $arg1 1)))
-    y = (+f (*f $c (at $arg1 1)) (*f $s (at $arg1 0)))
-    result (concat $x $y)
-]
+// rotate a vec2 by an angle and return the X and Y component, respectively
+vec2rotatex = [+f (*f (cos $arg3) $arg1) (*f (sin $arg3) $arg2)] // X cos(@) + Y sin(@)
+vec2rotatey = [-f (*f (cos $arg3) $arg2) (*f (sin $arg3) $arg1)] // Y cos(@) - X sin(@)
 
-// o p o_yaw p_yaw folder icon scale=0.016 offset mad=""
+// x y z angle icon scale=0.016 offsetx offsety mad
 radar_icon = [
-    local dir dist bx by
-    if $arg7 [] [ arg7 = 0.016 ]
-	if $arg8 [] [ arg8 = "0 0" ]
-	if $arg9 [] [ arg9 = "" ]
-    dir = (vec2scale (divf 1 $calcradarscale) (vec2sub $arg1 $arg2))
-    dist = (vec2magnitude $dir)
+    local dirx diry dist r_dirx r_diry bx by
+    if $arg6 [] [ arg6 = 0.016 ]
+	dirx = (*f (divf 1 $calcradarscale) (-f $getcamx $arg1))
+	diry = (*f (divf 1 $calcradarscale) (-f $getcamy $arg2))
+	dist = (sqrt (+f (*f $dirx $dirx) (*f $diry $diry)))
     if (>=f $dist 0.84) [
-        dir = (vec2scale (divf 0.84 $dist) $dir)
+		dirx = (*f (divf 0.84 $dist) $dirx)
+		diry = (*f (divf 0.84 $dist) $diry)
     ]
-    dir = (vec2rotate $dir (* -1 $arg3))
-    bx = (+f (at $arg8 0) (*f $MINIMAP_SIZE (at $dir 0)))
-    by = (+f (at $arg8 1) (*f $MINIMAP_SIZE (at $dir 1)))
-    uioffset $bx $by [ uiFastImgRotation $arg9 $arg5 $arg6 "" $arg4 $arg7 ]
+	r_dirx = (vec2rotatex $dirx $diry $getcamyaw)
+	r_diry = (vec2rotatey $dirx $diry $getcamyaw)
+    bx = (+f $arg7 (*f $MINIMAP_SIZE $r_dirx))
+    by = (+f $arg8 (*f $MINIMAP_SIZE $r_diry))
+    uioffset $bx $by [ uiFastImgRotation $arg9 "hud/" $arg5 "" $arg4 $arg6 ]
 ]
 
 .playerhud = [
@@ -169,43 +161,47 @@ radar_icon = [
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	if (&& $showminimap [m_ctf $getmode]) [
 		uispace $uiPad:L $uiPad:L [
-			local t o yaw
-			o = $getcampos
-			yaw = $getcamyaw
-			t = (? $isspectator (? (! (isspectator $getfollow)) (getclientteam $getfollow) $getteam) $getteam)
-			uiminimap (at $o 0) (at $o 1) $yaw $MINIMAP_SIZE        // minimap background
+			local cteam
+
+			if (>= $getfollow 0) [
+				cteam = (getclientteam $getfollow)
+			] [ cteam = $getteam ]
+
+			uiminimap $getcamx $getcamy $getcamyaw $MINIMAP_SIZE    // minimap background
 			uiFastImg "" "hud/" "radar" "" $MINIMAP_SIZE            // minimap border
+			
 			// flag bases
 			loop i $numflags [
-				radar_icon $o (flagbase $i) $yaw 0 "hud/" (+s "blip_" (? (= (flagteam $i) 1) "blue" "red"))
+				do [ radar_icon @(flagbase $i) 0 (+s "blip_" (? (= (flagteam $i) 1) "blue" "red")) ]
 			]
+			
 			// players
 			looplist cn (listclients 1 1) [
-				if (&& [! (isspectator $cn)] [= $t (getclientteam $cn)] [!=s $cn (? (isspectator $getclientnum) $getfollow $getclientnum)] [! (getclientflag $cn)]) [
-					if $radarteammates [
-						if (isdead $cn) [
-							radar_icon $o (getclientpos $cn) $yaw 0 "hud/" (+s "blip_" (? (= (getclientteam $cn) 1) "blue" "red") "_dead")
-						] [
-							radar_icon $o (getclientpos $cn) $yaw (- $yaw (getclientyaw $cn)) "hud/" (+s "blip_" (? (= (getclientteam $cn) 1) "blue" "red") "_alive")
-						]
+				if (&& $radarteammates [! (isspectator $cn)] [= $cteam (getclientteam $cn)] [!=s $cn (? $isspectator $getfollow $getclientnum)] [! (getclientflag $cn)]) [
+					if (isdead $cn) [
+						do [ radar_icon @(getclientpos $cn) 0 (+s "blip_" (? (= (getclientteam $cn) 1) "blue" "red") "_dead") ]
+					] [
+						do [ radar_icon @(getclientpos $cn) (- $getcamyaw (getclientyaw $cn)) (+s "blip_" (? (= (getclientteam $cn) 1) "blue" "red") "_alive") ]
 					]
 				]
 			]
+			
+			// flags
 			loop i $numflags [
 				case (flagstate $i) 0 [
 					// flag is at base
-					radar_icon $o (flagbase $i) $yaw 0 "hud/" (+s "blip_" (? (= (flagteam $i) 1) "blue" "red") "_flag") 0.0225 "0.018 -0.018"
+					do [ radar_icon @(flagbase $i) 0 (+s "blip_" (? (= (flagteam $i) 1) "blue" "red") "_flag") 0.0225 0.018 -0.018 ]
 				] 1 [
 					// a player has the flag
 					if (< (mod $getmillis 1000) 500) [
-						radar_icon $o (getclientpos (flagowner $i)) $yaw 0 "hud/" (+s "blip_" (? (= (flagteam $i) 1) "blue" "red") "_flag") 0.0225 "0.018 -0.018"
+						do [ radar_icon @(getclientpos (flagowner $i)) 0 (+s "blip_" (? (= (flagteam $i) 1) "blue" "red") "_flag") 0.0225 0.018 -0.018 ]
 					]
 				] 2 [
 					// flag is dropped somewhere
-					if (&& [< (mod $getmillis 300) 150] [>= (at (flagdroploc $i) 0) 0]) [
-						radar_icon $o (flagdroploc $i) $yaw 0 "hud/" (+s "blip_" (? (= (flagteam $i) 1) "blue" "red") "_flag") 0.0225 "0.018 -0.018"
+					if (< (mod $getmillis 300) 150) [
+						do [ radar_icon @(flagdroploc $i) 0 (+s "blip_" (? (= (flagteam $i) 1) "blue" "red") "_flag") 0.0225 0.018 -0.018 ]
 					]
-				]
+				] // 3 - flag fell under the map, don't show icon
 			]
 		] ; uialign- 1 -1
 	]

--- a/config/ui/hud.cfg
+++ b/config/ui/hud.cfg
@@ -128,15 +128,15 @@ radar_icon = [
 	dirx = (*f (divf 1 $calcradarscale) (-f $getcamx $arg1))
 	diry = (*f (divf 1 $calcradarscale) (-f $getcamy $arg2))
 	dist = (sqrt (+f (*f $dirx $dirx) (*f $diry $diry)))
-    if (>=f $dist 0.85) [
-		dirx = (*f (divf 0.85 $dist) $dirx)
-		diry = (*f (divf 0.85 $dist) $diry)
+    if (>=f $dist 0.9) [
+		dirx = (*f (divf 0.9 $dist) $dirx)
+		diry = (*f (divf 0.9 $dist) $diry)
     ]
 	r_dirx = (vec2rotatex $dirx $diry $getcamyaw)
 	r_diry = (vec2rotatey $dirx $diry $getcamyaw)
     bx = (+f $arg7 (*f $MINIMAP_SIZE $r_dirx))
     by = (+f $arg8 (*f $MINIMAP_SIZE $r_diry))
-    uioffset $bx $by [ uiFastImgRotation $arg9 "hud/" $arg5 "" $arg4 $arg6 ]
+    uispace -1 -1 [ uioffset $bx $by [ uiFastImgRotation $arg9 "hud/" $arg5 "" $arg4 $arg6 ] ]
 ]
 
 .playerhud = [

--- a/config/ui/lib.cfg
+++ b/config/ui/lib.cfg
@@ -219,12 +219,12 @@ uiFastImgStretched = [
 	uistretchedimage (+s $arg1 "data/interface/" $arg2 $arg3 $arg4 ".png") $arg6 $arg7 [ doargs $arg5 ]
 ]
 
-// uiFastImgRotation TEXCMD PATH1 PATH2 PATH3 ANGLE X Y [ children ]
-uiFastImgRotation = [
+// uiFastImgRotated TEXCMD PATH1 PATH2 PATH3 ANGLE X Y [ children ]
+uiFastImgRotated = [
 	if $arg5 [] [ arg5 = 0 ]
 	if $arg6 [] [ arg6 = $uiPad:SXL ]
 	if $arg7 [] [ arg7 = $arg6 ]
-	uiimagerotation (+s $arg1 "data/interface/" $arg2 $arg3 $arg4 ".png") $arg5 $arg6 $arg7 [ doargs $arg8 ]
+	uirotatedimage (+s $arg1 "data/interface/" $arg2 $arg3 $arg4 ".png") $arg5 $arg6 $arg7 [ doargs $arg8 ]
 ]
 
 // uiShadowedImg TEXCMD PATH1 PATH2 PATH3 X Y OFFSET-MUL

--- a/config/ui/lib.cfg
+++ b/config/ui/lib.cfg
@@ -219,6 +219,14 @@ uiFastImgStretched = [
 	uistretchedimage (+s $arg1 "data/interface/" $arg2 $arg3 $arg4 ".png") $arg6 $arg7 [ doargs $arg5 ]
 ]
 
+// uiFastImgRotation TEXCMD PATH1 PATH2 PATH3 ANGLE X Y [ children ]
+uiFastImgRotation = [
+	if $arg5 [] [ arg5 = 0 ]
+	if $arg6 [] [ arg6 = $uiPad:SXL ]
+	if $arg7 [] [ arg7 = $arg6 ]
+	uiimagerotation (+s $arg1 "data/interface/" $arg2 $arg3 $arg4 ".png") $arg5 $arg6 $arg7 [ doargs $arg8 ]
+]
+
 // uiShadowedImg TEXCMD PATH1 PATH2 PATH3 X Y OFFSET-MUL
 uiShadowedImg = [
 	if $arg7 [] [ arg7 = 1 ]

--- a/source/engine/rendergl.cpp
+++ b/source/engine/rendergl.cpp
@@ -1242,6 +1242,9 @@ ICOMMAND(getcampos, "", (),
     defformatstring(pos, "%s %s %s", floatstr(camera1->o.x), floatstr(camera1->o.y), floatstr(camera1->o.z));
     result(pos);
 });
+ICOMMAND(getcamx, "", (), floatret(camera1->o.x));
+ICOMMAND(getcamy, "", (), floatret(camera1->o.y));
+ICOMMAND(getcamz, "", (), floatret(camera1->o.z));
 
 vec worldpos, camdir, camright, camup;
 

--- a/source/engine/shader.cpp
+++ b/source/engine/shader.cpp
@@ -1130,7 +1130,7 @@ ICOMMAND(forceshader, "s", (const char *name), useshaderbyname(name));
 
 void shader(int *type, char *name, char *vs, char *ps)
 {
-    if(lookupshaderbyname(name)) return;
+//    if(lookupshaderbyname(name)) return;
 
     defformatstring(info, "shader %s", name);
     renderprogress(loadprogress, info);

--- a/source/engine/shader.cpp
+++ b/source/engine/shader.cpp
@@ -1130,7 +1130,7 @@ ICOMMAND(forceshader, "s", (const char *name), useshaderbyname(name));
 
 void shader(int *type, char *name, char *vs, char *ps)
 {
-//    if(lookupshaderbyname(name)) return;
+    if(lookupshaderbyname(name)) return;
 
     defformatstring(info, "shader %s", name);
     renderprogress(loadprogress, info);

--- a/source/engine/ui.cpp
+++ b/source/engine/ui.cpp
@@ -1521,6 +1521,7 @@ namespace UI
             changedraw(CHANGE_SHADER);
 
             SETSHADER(hudminimap);
+            LOCALPARAMF(minimapalpha, game::minimapalpha);
             bindminimap();
         }
 

--- a/source/engine/ui.cpp
+++ b/source/engine/ui.cpp
@@ -18,7 +18,8 @@ namespace UI
         gle::attribf(x,   y+h); gle::attribf(tx,    ty+th);
     }
 
-    static void quads_rotation(float x, float y, float w, float h, float angle, float tx = 0, float ty = 0, float tw = 1, float th = 1) {
+    static void quads_rotation(float x, float y, float w, float h, float angle, float tx = 0, float ty = 0, float tw = 1, float th = 1)
+    {
         vec v(-0.5, -0.5, 0);
         v.rotate_around_z((90+angle)*RAD);
         gle::attribf(x - w*v.x + w/2, y + h*v.y + h/2); gle::attribf(tx,    ty);
@@ -1515,7 +1516,6 @@ namespace UI
 
         void bindtex()
         {
-            //changedraw();
             changedraw(CHANGE_SHADER);
 
             SETSHADER(hudminimap);
@@ -1528,7 +1528,8 @@ namespace UI
             vecfromyawpitch(yaw, 0, 1, 0, dir);
             float scale = game::calcradarscale();
             bindtex();
-            loopi(16) {
+            loopi(16)
+            {
                 vec v = vec(0, -1, 0).rotate_around_z(i/16.0f*2*M_PI);
                 gle::attribf(sx + 0.5f*w*(1.0f + v.x), sy + 0.5f*h*(1.0f + v.y));
                 vec tc = vec(dir).rotate_around_z(i/16.0f*2*M_PI);
@@ -1584,11 +1585,8 @@ namespace UI
             if(tex != notexture)
             {
                 bindtex();
-                if(angle != 0) {
-                    quads_rotation(sx, sy, w, h, angle);
-                } else {
-                    quads(sx, sy, w, h);
-                }
+                if(angle != 0) quads_rotation(sx, sy, w, h, angle);
+                else quads(sx, sy, w, h);
             }
 
             Object::draw(sx, sy);

--- a/source/engine/ui.cpp
+++ b/source/engine/ui.cpp
@@ -18,6 +18,15 @@ namespace UI
         gle::attribf(x,   y+h); gle::attribf(tx,    ty+th);
     }
 
+    static void quads_rotation(float x, float y, float w, float h, float angle, float tx = 0, float ty = 0, float tw = 1, float th = 1) {
+        vec v(-0.5, -0.5, 0);
+        v.rotate_around_z((90+angle)*RAD);
+        gle::attribf(x - w*v.x + w/2, y + h*v.y + h/2); gle::attribf(tx,    ty);
+        gle::attribf(x - w*v.y + w/2, y - h*v.x + h/2); gle::attribf(tx+tw, ty);
+        gle::attribf(x + w*v.x + w/2, y - h*v.y + h/2); gle::attribf(tx+tw, ty+th);
+        gle::attribf(x + w*v.y + w/2, y + h*v.x + h/2); gle::attribf(tx,    ty+th);
+    }
+
 #if 0
     static void quad(float x, float y, float w, float h, float tx = 0, float ty = 0, float tw = 1, float th = 1)
     {
@@ -1471,16 +1480,75 @@ namespace UI
         return false;
     }
 
+    struct Minimap : Filler
+    {
+        float yaw, size;
+        vec origin;
+
+        void setup(vec origin_, float yaw_, float size_)
+        {
+            origin = vec(origin_);
+            yaw = yaw_;
+            size = size_;
+            Filler::setup(size_, size_);
+        }
+
+        static const char *typestr() { return "#Minimap"; }
+        const char *gettype() const { return typestr(); }
+
+        bool target(float cx, float cy)
+        {
+            return true;
+        }
+
+        void startdraw()
+        {
+            gle::defvertex(2);
+            gle::deftexcoord0();
+            gle::begin(GL_TRIANGLE_FAN);
+        }
+
+        void enddraw()
+        {
+            gle::end();
+        }
+
+        void bindtex()
+        {
+            //changedraw();
+            changedraw(CHANGE_SHADER);
+
+            SETSHADER(hudminimap);
+            bindminimap();
+        }
+
+        void draw(float sx, float sy)
+        {
+            vec pos = vec(origin).sub(minimapcenter).mul(minimapscale).add(0.5f), dir;
+            vecfromyawpitch(yaw, 0, 1, 0, dir);
+            float scale = game::calcradarscale();
+            bindtex();
+            loopi(16) {
+                vec v = vec(0, -1, 0).rotate_around_z(i/16.0f*2*M_PI);
+                gle::attribf(sx + 0.5f*w*(1.0f + v.x), sy + 0.5f*h*(1.0f + v.y));
+                vec tc = vec(dir).rotate_around_z(i/16.0f*2*M_PI);
+                gle::attribf(1.0f - (pos.x + tc.x*scale*minimapscale.x), pos.y + tc.y*scale*minimapscale.y);
+            }
+        }
+    };
+
     struct Image : Filler
     {
         static Texture *lasttex;
 
         Texture *tex;
+        float angle;
 
-        void setup(Texture *tex_, float minw_ = 0, float minh_ = 0)
+        void setup(Texture *tex_, float minw_ = 0, float minh_ = 0, float angle_ = 0)
         {
             Filler::setup(minw_, minh_);
             tex = tex_;
+            angle = angle_;
         }
 
         static const char *typestr() { return "#Image"; }
@@ -1516,7 +1584,11 @@ namespace UI
             if(tex != notexture)
             {
                 bindtex();
-                quads(sx, sy, w, h);
+                if(angle != 0) {
+                    quads_rotation(sx, sy, w, h, angle);
+                } else {
+                    quads(sx, sy, w, h);
+                }
             }
 
             Object::draw(sx, sy);
@@ -3439,8 +3511,14 @@ namespace UI
     ICOMMAND(uikeyfield, "riefe", (ident *var, int *length, uint *onchange, float *scale, uint *children),
         BUILD(KeyField, o, o->setup(var, *length, onchange, (*scale <= 0 ? 1 : *scale) * uitextscale), children));
 
+    ICOMMAND(uiminimap, "ffffe", (float *ox, float *oy, float *yaw, float *size, uint *children),
+        BUILD(Minimap, o, o->setup(vec(*ox, *oy, 0), *yaw, *size), children));
+
     ICOMMAND(uiimage, "sffe", (char *texname, float *minw, float *minh, uint *children),
         BUILD(Image, o, o->setup(textureload(texname, 3, true, false), *minw, *minh), children));
+    
+    ICOMMAND(uiimagerotation, "sfffe", (char *texname, float *angle, float *minw, float *minh, uint *children),
+        BUILD(Image, o, o->setup(textureload(texname, 3, true, false), *minw, *minh, *angle), children));
 
     ICOMMAND(uistretchedimage, "sffe", (char *texname, float *minw, float *minh, uint *children),
         BUILD(StretchedImage, o, o->setup(textureload(texname, 3, true, false), *minw, *minh), children));

--- a/source/engine/ui.cpp
+++ b/source/engine/ui.cpp
@@ -3518,7 +3518,7 @@ namespace UI
     ICOMMAND(uiimage, "sffe", (char *texname, float *minw, float *minh, uint *children),
         BUILD(Image, o, o->setup(textureload(texname, 3, true, false), *minw, *minh), children));
     
-    ICOMMAND(uiimagerotation, "sfffe", (char *texname, float *angle, float *minw, float *minh, uint *children),
+    ICOMMAND(uirotatedimage, "sfffe", (char *texname, float *angle, float *minw, float *minh, uint *children),
         BUILD(Image, o, o->setup(textureload(texname, 3, true, false), *minw, *minh, *angle), children));
 
     ICOMMAND(uistretchedimage, "sffe", (char *texname, float *minw, float *minh, uint *children),

--- a/source/engine/ui.cpp
+++ b/source/engine/ui.cpp
@@ -1483,14 +1483,16 @@ namespace UI
 
     struct Minimap : Filler
     {
-        float yaw, size;
         vec origin;
+        float yaw, size;
+        int sides;
 
-        void setup(vec origin_, float yaw_, float size_)
+        void setup(vec origin_, float yaw_, float size_, int sides_)
         {
             origin = vec(origin_);
             yaw = yaw_;
             size = size_;
+            sides = clamp(sides_, 3, 64);
             Filler::setup(size_, size_);
         }
 
@@ -1528,11 +1530,11 @@ namespace UI
             vecfromyawpitch(yaw, 0, 1, 0, dir);
             float scale = game::calcradarscale();
             bindtex();
-            loopi(16)
+            loopi(sides)
             {
-                vec v = vec(0, -1, 0).rotate_around_z(i/16.0f*2*M_PI);
+                vec v = vec(0, -1, 0).rotate_around_z(i/float(sides)*2*M_PI);
                 gle::attribf(sx + 0.5f*w*(1.0f + v.x), sy + 0.5f*h*(1.0f + v.y));
-                vec tc = vec(dir).rotate_around_z(i/16.0f*2*M_PI);
+                vec tc = vec(dir).rotate_around_z(i/float(sides)*2*M_PI);
                 gle::attribf(1.0f - (pos.x + tc.x*scale*minimapscale.x), pos.y + tc.y*scale*minimapscale.y);
             }
         }
@@ -3509,8 +3511,8 @@ namespace UI
     ICOMMAND(uikeyfield, "riefe", (ident *var, int *length, uint *onchange, float *scale, uint *children),
         BUILD(KeyField, o, o->setup(var, *length, onchange, (*scale <= 0 ? 1 : *scale) * uitextscale), children));
 
-    ICOMMAND(uiminimap, "ffffe", (float *ox, float *oy, float *yaw, float *size, uint *children),
-        BUILD(Minimap, o, o->setup(vec(*ox, *oy, 0), *yaw, *size), children));
+    ICOMMAND(uiminimap, "ffffie", (float *ox, float *oy, float *yaw, float *size, int *sides, uint *children),
+        BUILD(Minimap, o, o->setup(vec(*ox, *oy, 0), *yaw, *size, *sides), children));
 
     ICOMMAND(uiimage, "sffe", (char *texname, float *minw, float *minh, uint *children),
         BUILD(Image, o, o->setup(textureload(texname, 3, true, false), *minw, *minh), children));

--- a/source/game/ctf.h
+++ b/source/game/ctf.h
@@ -864,6 +864,13 @@ struct ctfclientmode : clientmode
 
 extern ctfclientmode ctfmode;
 ICOMMAND(dropflag, "", (), { ctfmode.trydropflag(); });
+ICOMMAND(numflags, "", (), { intret(ctfmode.flags.length()); });
+ICOMMAND(flagbase, "i", (int *n), { result(ctfmode.flags.inrange(*n) ? tempformatstring("%f %f %f", ctfmode.flags[*n].spawnloc.x, ctfmode.flags[*n].spawnloc.y, ctfmode.flags[*n].spawnloc.z) : "0 0 0"); });
+ICOMMAND(flagteam, "i", (int *n), { intret(ctfmode.flags.inrange(*n) ? ctfmode.flags[*n].team : 0); });
+// 0 = at base, 1 = stolen, 2 = dropped
+ICOMMAND(flagstate, "i", (int *n), { intret(ctfmode.flags.inrange(*n) ? (ctfmode.flags[*n].owner ? 1 : ctfmode.flags[*n].droptime ? 2 : 0) : 0); });
+ICOMMAND(flagdroploc, "i", (int *n), { result(ctfmode.flags.inrange(*n) ? tempformatstring("%f %f %f", ctfmode.flags[*n].droploc.x, ctfmode.flags[*n].droploc.y, ctfmode.flags[*n].droploc.z) : "0 0 0"); });
+ICOMMAND(flagowner, "i", (int *n), { intret(ctfmode.flags.inrange(*n) ? ctfmode.flags[*n].owner->clientnum : -1); });
 
 #endif
 

--- a/source/game/ctf.h
+++ b/source/game/ctf.h
@@ -868,7 +868,8 @@ ICOMMAND(numflags, "", (), { intret(ctfmode.flags.length()); });
 ICOMMAND(flagbase, "i", (int *n), { result(ctfmode.flags.inrange(*n) ? tempformatstring("%f %f %f", ctfmode.flags[*n].spawnloc.x, ctfmode.flags[*n].spawnloc.y, ctfmode.flags[*n].spawnloc.z) : "0 0 0"); });
 ICOMMAND(flagteam, "i", (int *n), { intret(ctfmode.flags.inrange(*n) ? ctfmode.flags[*n].team : 0); });
 // 0 = at base, 1 = stolen, 2 = dropped, 3 = fallen under the map
-ICOMMAND(flagstate, "i", (int *n), {
+ICOMMAND(flagstate, "i", (int *n),
+{
     if(!ctfmode.flags.inrange(*n)) return intret(0);
     intret(ctfmode.flags[*n].owner ? 1 : (ctfmode.flags[*n].droptime ? (ctfmode.flags[*n].droploc.x < 0 ? 3 : 2) : 0));
 });

--- a/source/game/ctf.h
+++ b/source/game/ctf.h
@@ -867,8 +867,11 @@ ICOMMAND(dropflag, "", (), { ctfmode.trydropflag(); });
 ICOMMAND(numflags, "", (), { intret(ctfmode.flags.length()); });
 ICOMMAND(flagbase, "i", (int *n), { result(ctfmode.flags.inrange(*n) ? tempformatstring("%f %f %f", ctfmode.flags[*n].spawnloc.x, ctfmode.flags[*n].spawnloc.y, ctfmode.flags[*n].spawnloc.z) : "0 0 0"); });
 ICOMMAND(flagteam, "i", (int *n), { intret(ctfmode.flags.inrange(*n) ? ctfmode.flags[*n].team : 0); });
-// 0 = at base, 1 = stolen, 2 = dropped
-ICOMMAND(flagstate, "i", (int *n), { intret(ctfmode.flags.inrange(*n) ? (ctfmode.flags[*n].owner ? 1 : ctfmode.flags[*n].droptime ? 2 : 0) : 0); });
+// 0 = at base, 1 = stolen, 2 = dropped, 3 = fallen under the map
+ICOMMAND(flagstate, "i", (int *n), {
+    if(!ctfmode.flags.inrange(*n)) return intret(0);
+    intret(ctfmode.flags[*n].owner ? 1 : (ctfmode.flags[*n].droptime ? (ctfmode.flags[*n].droploc.x < 0 ? 3 : 2) : 0));
+});
 ICOMMAND(flagdroploc, "i", (int *n), { result(ctfmode.flags.inrange(*n) ? tempformatstring("%f %f %f", ctfmode.flags[*n].droploc.x, ctfmode.flags[*n].droploc.y, ctfmode.flags[*n].droploc.z) : "0 0 0"); });
 ICOMMAND(flagowner, "i", (int *n), { intret(ctfmode.flags.inrange(*n) ? ctfmode.flags[*n].owner->clientnum : -1); });
 

--- a/source/game/gameclient.cpp
+++ b/source/game/gameclient.cpp
@@ -11,6 +11,7 @@ namespace game
     {
         return clamp(max(minimapradius.x, minimapradius.y)/3, float(minradarscale), float(maxradarscale));
     }
+    ICOMMAND(calcradarscale, "", (), floatret(calcradarscale()));
 
     void drawminimap(gameent *d, float x, float y, float s)
     {
@@ -316,6 +317,18 @@ namespace game
         return d && d->state!=CS_SPECTATOR ? getplayercolor(d, m_teammode && validteam(d->team) ? d->team : 0) : 0xFFFFFF;
     }
     ICOMMAND(getclientcolor, "i", (int *cn), intret(getclientcolor(*cn)));
+
+    const char *getclientpos(int cn) {
+        gameent *d = getclient(cn);
+        return d && d->state != CS_SPECTATOR ? tempformatstring("%f %f %f", d->o.x, d->o.y, d->o.z) : "0 0 0";
+    }
+    ICOMMAND(getclientpos, "i", (int *cn), result(getclientpos(*cn)));
+
+    int getclientyaw(int cn) {
+        gameent *d = getclient(cn);
+        return d && d->state != CS_SPECTATOR ? d->yaw : 0;
+    }
+    ICOMMAND(getclientyaw, "i", (int *cn), intret(getclientyaw(*cn)));
 
     ICOMMAND(getclientfrags, "i", (int *cn),
     {

--- a/source/game/gameclient.cpp
+++ b/source/game/gameclient.cpp
@@ -5,7 +5,7 @@ namespace game
     VARP(minradarscale, 0, 384, 10000);
     VARP(maxradarscale, 1, 1024, 10000);
     VARP(radarteammates, 0, 1, 1);
-    FVARP(minimapalpha, 0, 1, 1);
+    FVARFP(minimapalpha, 0, 1, 1, { execident("minimapshader"); });
 
     float calcradarscale()
     {

--- a/source/game/gameclient.cpp
+++ b/source/game/gameclient.cpp
@@ -5,7 +5,7 @@ namespace game
     VARP(minradarscale, 0, 384, 10000);
     VARP(maxradarscale, 1, 1024, 10000);
     VARP(radarteammates, 0, 1, 1);
-    FVARFP(minimapalpha, 0, 1, 1, { execident("minimapshader"); });
+    FVARP(minimapalpha, 0, 1, 1);
 
     float calcradarscale()
     {

--- a/source/game/gameclient.cpp
+++ b/source/game/gameclient.cpp
@@ -318,13 +318,15 @@ namespace game
     }
     ICOMMAND(getclientcolor, "i", (int *cn), intret(getclientcolor(*cn)));
 
-    const char *getclientpos(int cn) {
+    const char *getclientpos(int cn)
+    {
         gameent *d = getclient(cn);
         return d && d->state != CS_SPECTATOR ? tempformatstring("%f %f %f", d->o.x, d->o.y, d->o.z) : "0 0 0";
     }
     ICOMMAND(getclientpos, "i", (int *cn), result(getclientpos(*cn)));
 
-    int getclientyaw(int cn) {
+    int getclientyaw(int cn)
+    {
         gameent *d = getclient(cn);
         return d && d->state != CS_SPECTATOR ? d->yaw : 0;
     }

--- a/source/shared/igame.h
+++ b/source/shared/igame.h
@@ -96,6 +96,8 @@ namespace game
     extern bool needminimap();
 
     extern int mapdeath;
+
+    extern float calcradarscale();
 }
 
 namespace server

--- a/source/shared/igame.h
+++ b/source/shared/igame.h
@@ -98,6 +98,7 @@ namespace game
     extern int mapdeath;
 
     extern float calcradarscale();
+    extern float minimapalpha;
 }
 
 namespace server


### PR DESCRIPTION
Add a `uiminimap` widget that renders the minimap background in the UI

The radar icons are placed with cubescript

The minimap texture can be manipulated with the `hudminimap` shader