### PR TITLE
Add server game version to the server browser

### DIFF
--- a/config/ui/menus/server_browser.cfg
+++ b/config/ui/menus/server_browser.cfg
@@ -171,6 +171,9 @@ uiServer = [
 					uihlist $uiPad:L [
 						uifontcolortext "wide" "::" $c_gray 0.6
 						uicolortext (servinfodesc $arg1) (? $arg2 $c_olive $c_white) 0.6
+						if (!= (servinfogameversion $arg1) $currentversion) [
+							uicolortext (formatversion (servinfogameversion $arg1)) $c_gray 0.6
+						]
 					]
 				]
 				uihlist $uiPad:L [

--- a/source/Makefile
+++ b/source/Makefile
@@ -308,6 +308,7 @@ engine/main.o: engine/engine.h shared/cube.h shared/tools.h shared/geom.h
 engine/main.o: shared/ents.h shared/command.h shared/glexts.h shared/glemu.h
 engine/main.o: shared/iengine.h shared/igame.h engine/world.h engine/octa.h
 engine/main.o: engine/light.h engine/texture.h engine/bih.h engine/model.h
+engine/main.o: engine/version.h
 engine/material.o: engine/engine.h shared/cube.h shared/tools.h shared/geom.h
 engine/material.o: shared/ents.h shared/command.h shared/glexts.h
 engine/material.o: shared/glemu.h shared/iengine.h shared/igame.h
@@ -504,6 +505,7 @@ standalone/engine/command.o: shared/iengine.h shared/igame.h engine/world.h
 standalone/engine/server.o: engine/engine.h shared/cube.h shared/tools.h
 standalone/engine/server.o: shared/geom.h shared/ents.h shared/command.h
 standalone/engine/server.o: shared/iengine.h shared/igame.h engine/world.h
+standalone/engine/server.o: engine/version.h
 standalone/engine/worldio.o: engine/engine.h shared/cube.h shared/tools.h
 standalone/engine/worldio.o: shared/geom.h shared/ents.h shared/command.h
 standalone/engine/worldio.o: shared/iengine.h shared/igame.h engine/world.h

--- a/source/engine/main.cpp
+++ b/source/engine/main.cpp
@@ -1,6 +1,7 @@
 // main.cpp: initialisation & main loop
 
 #include "engine.h"
+#include "version.h"
 
 #ifdef SDL_VIDEO_DRIVER_X11
 #include "SDL_syswm.h"
@@ -1096,21 +1097,6 @@ int getclockmillis()
 }
 
 VAR(numcpus, 1, 1, 16);
-
-#define VERSION_MAJOR 1
-#define VERSION_MINOR 0
-#define VERSION_PATCH 0
-#define VERSION_EDITION "Ymir"
-
-VAR(currentversion, 1, VERSION_MAJOR << 16 | VERSION_MINOR << 8 | VERSION_PATCH, 0);
-SVARRO(currentversionstring, tempformatstring("v%d.%d.%d (%s Edition)", VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH, VERSION_EDITION));
-
-const char *formatversion(int version) {
-    static string s;
-    formatstring(s, "v%d.%d.%d", version >> 16, version >> 8 & 0xFF, version & 0xFF);
-    return s;
-}
-ICOMMAND(formatversion, "i", (int *version), result(formatversion(*version)));
 
 int main(int argc, char **argv)
 {

--- a/source/engine/main.cpp
+++ b/source/engine/main.cpp
@@ -1097,7 +1097,20 @@ int getclockmillis()
 
 VAR(numcpus, 1, 1, 16);
 
-SVARRO(currentversionstring, "v1.0.0 (Ymir Edition)");
+#define VERSION_MAJOR 1
+#define VERSION_MINOR 0
+#define VERSION_PATCH 0
+#define VERSION_EDITION "Ymir"
+
+VAR(currentversion, 1, VERSION_MAJOR << 16 | VERSION_MINOR << 8 | VERSION_PATCH, 0);
+SVARRO(currentversionstring, tempformatstring("v%d.%d.%d (%s Edition)", VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH, VERSION_EDITION));
+
+const char *formatversion(int version) {
+    static string s;
+    formatstring(s, "v%d.%d.%d", version >> 16, version >> 8 & 0xFF, version & 0xFF);
+    return s;
+}
+ICOMMAND(formatversion, "i", (int *version), result(formatversion(*version)));
 
 int main(int argc, char **argv)
 {

--- a/source/engine/server.cpp
+++ b/source/engine/server.cpp
@@ -1132,6 +1132,7 @@ bool serveroption(char *opt)
 vector<const char *> gameargs;
 
 #ifdef STANDALONE
+#include "version.h"
 int main(int argc, char **argv)
 {
     setlogfile(NULL);

--- a/source/engine/serverbrowser.cpp
+++ b/source/engine/serverbrowser.cpp
@@ -300,6 +300,7 @@ struct serverinfo : servinfo, pingattempts
         clearpings();
         protocol = -1;
         numplayers = maxplayers = 0;
+        gameversion = 0;
         attr.setsize(0);
     }
 
@@ -544,6 +545,12 @@ void checkpings()
         filtertext(si->map, text, false, false, false);
         getstring(text, p);
         filtertext(si->desc, text, true, false);
+        if(p.remaining()) {
+            si->gameversion = getint(p);
+        } else {
+            // if no game version is reported, the server must be running 1.0.0
+            si->gameversion = 1 << 16;
+        }
     }
 }
 
@@ -597,6 +604,7 @@ ICOMMAND(servinfomap, "i", (int *i), GETSERVERINFO(*i, si, result(si.map)));
 ICOMMAND(servinfoping, "i", (int *i), GETSERVERINFO(*i, si, intret(si.ping)));
 ICOMMAND(servinfonumplayers, "i", (int *i), GETSERVERINFO(*i, si, intret(si.numplayers)));
 ICOMMAND(servinfomaxplayers, "i", (int *i), GETSERVERINFO(*i, si, intret(si.maxplayers)));
+ICOMMAND(servinfogameversion, "i", (int *i), GETSERVERINFO(*i, si, intret(si.gameversion)));
 ICOMMAND(servinfoplayers, "i", (int *i),
     GETSERVERINFO(*i, si,
     {

--- a/source/engine/serverbrowser.cpp
+++ b/source/engine/serverbrowser.cpp
@@ -545,9 +545,12 @@ void checkpings()
         filtertext(si->map, text, false, false, false);
         getstring(text, p);
         filtertext(si->desc, text, true, false);
-        if(p.remaining()) {
+        if(p.remaining())
+        {
             si->gameversion = getint(p);
-        } else {
+        }
+        else
+        {
             // if no game version is reported, the server must be running 1.0.0
             si->gameversion = 1 << 16;
         }

--- a/source/engine/version.h
+++ b/source/engine/version.h
@@ -1,0 +1,20 @@
+#ifndef __VERSION_H__
+#define __VERSION_H__
+
+#define VERSION_MAJOR 1
+#define VERSION_MINOR 0
+#define VERSION_PATCH 0
+#define VERSION_EDITION "Ymir"
+
+VAR(currentversion, 1, VERSION_MAJOR << 16 | VERSION_MINOR << 8 | VERSION_PATCH, 0);
+SVARRO(currentversionstring, tempformatstring("v%d.%d.%d (%s Edition)", VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH, VERSION_EDITION));
+
+const char *formatversion(int version)
+{
+    static string s;
+    formatstring(s, "v%d.%d.%d", version >> 16, version >> 8 & 0xFF, version & 0xFF);
+    return s;
+}
+ICOMMAND(formatversion, "i", (int *version), result(formatversion(*version)));
+
+#endif

--- a/source/game/gameserver.cpp
+++ b/source/game/gameserver.cpp
@@ -4594,6 +4594,7 @@ namespace server
         }
         sendstring(smapname, p);
         sendstring(servername, p);
+        putint(p, currentversion);
         sendserverinforeply(p);
     }
 

--- a/source/shared/iengine.h
+++ b/source/shared/iengine.h
@@ -242,6 +242,7 @@ extern void renderentring(const extentity &e, float radius, int axis = 0);
 
 // main
 extern void fatal(const char *s, ...) PRINTFARGS(1, 2);
+extern int currentversion;
 
 // rendertext
 extern bool setfont(const char *name);
@@ -520,10 +521,10 @@ extern bool isdedicatedserver();
 struct servinfo
 {
     string name, map, desc;
-    int protocol, numplayers, maxplayers, ping;
+    int protocol, numplayers, maxplayers, gameversion, ping;
     vector<int> attr;
 
-    servinfo() : protocol(INT_MIN), numplayers(0), maxplayers(0)
+    servinfo() : protocol(INT_MIN), numplayers(0), maxplayers(0), gameversion(0)
     {
         name[0] = map[0] = desc[0] = '\0';
     }


### PR DESCRIPTION
Appends the game version to the server info reply so it can be shown in the server browser.
This does not break older clients, they will just ignore the extra data.