### PR TITLE
Make flag lights stop flickering

### DIFF
--- a/source/engine/renderlights.cpp
+++ b/source/engine/renderlights.cpp
@@ -2033,6 +2033,7 @@ vector<int> lightorder;
 hashset<lightbatch> lightbatcher(128);
 vector<lightbatch *> lightbatches;
 vector<shadowmapinfo> shadowmaps;
+vector<lightinfo> gamelights;
 
 void clearshadowcache()
 {
@@ -3581,6 +3582,11 @@ void viewlightscissor()
     }
 }
 
+void addgamelight(vec o, vec color, float radius)
+{
+    gamelights.add(lightinfo(o, color, radius));
+}
+
 void collectlights()
 {
     if(lights.length()) return;
@@ -3601,6 +3607,18 @@ void collectlights()
         lightinfo &l = lights.add(lightinfo(i, *e));
         if(l.validscissor()) lightorder.add(lights.length()-1);
     }
+
+    loopv(gamelights)
+    {
+        if(smviscull)
+        {
+            if(isfoggedsphere(gamelights[i].radius, gamelights[i].o)) continue;
+            if(pvsoccludedsphere(gamelights[i].o, gamelights[i].radius)) continue;
+        }
+        lights.add(gamelights[i]);
+        if(gamelights[i].validscissor()) lightorder.add(lights.length()-1);
+    }
+    gamelights.setsize(0);
 
     int numdynlights = 0;
     if(!drawtex)

--- a/source/game/ctf.h
+++ b/source/game/ctf.h
@@ -420,7 +420,7 @@ struct ctfclientmode : clientmode
             if(f.team==1) color = vec(0.25f, 0.25f, 1);
             else if(f.team==2) color = vec(1, 0.25f, 0.25f);
             else color = vec(0.25f, 0.25f, 0.25f);
-            adddynlight(pos, 32, color, 1, 64);
+            addgamelight(pos, color.mul(255.f * (0.625f - 0.375f * cos(2 * PI * lastmillis / 1000.f))), 32);
             if(self->state!=CS_EDITING) f.chan = playsound(S_FLAGLOOP, NULL, f.owner == self? NULL: &pos, NULL, 0, -1, 500, f.chan, 200);
             else
             {

--- a/source/shared/iengine.h
+++ b/source/shared/iengine.h
@@ -287,6 +287,7 @@ extern void packvslot(vector<uchar> &buf, const VSlot *vs);
 // renderlights
 
 enum { L_NOSHADOW = 1<<0, L_NODYNSHADOW = 1<<1, L_VOLUMETRIC = 1<<2, L_NOSPEC = 1<<3, L_SMALPHA = 1<<4 };
+void addgamelight(vec o, vec color, float radius);
 
 // dynlight
 enum


### PR DESCRIPTION
Currently, the improper use of dynlights produces an annoying flickering effect around the flags. This is especially noticeable on the hudgun when holding the flag, and in glass reflections.

The solution is to replace the dynlights, which persist for multiple frames and vary in intensity over time, with lights that only last a single frame.