### PR TITLE
HSV adjustments and texture transformations

### DIFF
--- a/config/glsl/hud.cfg
+++ b/config/glsl/hud.cfg
@@ -61,10 +61,11 @@ shader 0 "hudrgb" [
     uniform mat4 hudmatrix;
     varying vec2 texcoord0;
     varying vec4 colorscale;
+    uniform vec4 previewtransform;
     void main(void)
     {
         gl_Position = hudmatrix * vvertex;
-        texcoord0 = vtexcoord0; 
+        texcoord0 = mat2(previewtransform) * vtexcoord0; 
         colorscale = vcolor;
     }
 ] [

--- a/config/glsl/hud.cfg
+++ b/config/glsl/hud.cfg
@@ -68,14 +68,17 @@ shader 0 "hudrgb" [
         colorscale = vcolor;
     }
 ] [
+    @glsl_hsv
+
     uniform sampler2D tex0;
     varying vec2 texcoord0;
     varying vec4 colorscale;
+    uniform vec4 previewhsv;
     fragdata(0) vec4 fragcolor;
     void main(void)
     {
         vec4 color = texture2D(tex0, texcoord0);
-        fragcolor.rgb = colorscale.rgb * color.rgb;
+        fragcolor.rgb = applyHSV(colorscale.rgb * color.rgb, previewhsv.rgb);
         fragcolor.a   = colorscale.a;
     }
 ]

--- a/config/glsl/shared.cfg
+++ b/config/glsl/shared.cfg
@@ -175,4 +175,15 @@ screentexcoord = [
     ]
 ]
 
+glsl_hsv = [
+    const mat3 rgb2yiq = mat3(0.30, 0.599, 0.213, 0.59, -0.2773, -0.5251, 0.11, -0.3217, 0.3121);
+    const mat3 yiq2rgb = mat3(1, 1, 1, 0.9469, -0.2748, -1.1, 0.6236, -0.6357, 1.7);
+    vec3 applyHSV(vec3 c, vec3 delta) {
+        vec3 yiq = rgb2yiq * c;
+        float hue = atan(yiq.b, yiq.g) - delta.r * 3.14159265358 / 180.0;
+        float chroma = sqrt(yiq.b*yiq.b+yiq.g*yiq.g) * delta.g;
+        vec3 final_yiq = vec3(yiq.r * delta.b, chroma * cos(hue), chroma * sin(hue));
+        return yiq2rgb * final_yiq;
+    }
+]
 

--- a/config/glsl/world.cfg
+++ b/config/glsl/world.cfg
@@ -239,6 +239,9 @@ worldshader "specmapworld" "sS"
 worldshader "glowworld" "g"
 worldshader "pulseglowworld" "gG"
 
+worldshader "specpulseglowworld" "sgG"
+worldshader "specmappulseglowworld" "sSgG"
+
 worldshader "glowalphaworld" "gm"
 worldshader "pulseglowalphaworld" "gGm"
 

--- a/config/glsl/world.cfg
+++ b/config/glsl/world.cfg
@@ -104,11 +104,14 @@ worldvariantshader = [
             ])
         }
     ] [
+        @glsl_hsv
+        
         @(if (wtopt "A") [result [
             @(gfetchdefs refractlight)
             uniform vec4 refractparams;
         ]])
         uniform vec4 colorparams;
+        uniform vec4 hsv;
         uniform sampler2D diffusemap;
         @(? (|| $msaalight [&& $msaasamples [! (wtopt "a")]]) [uniform float hashid;])
         varying vec3 nvec;
@@ -145,7 +148,7 @@ worldvariantshader = [
                 vec4 diffuse = texture2D(diffusemap, texcoord0);   
             ]])
 
-            gcolor.rgb = diffuse.rgb*colorparams.rgb;
+            gcolor.rgb = applyHSV(diffuse.rgb*colorparams.rgb, hsv.rgb);
 
             @(if (wtopt "r") [result [
                 vec3 camvecn = normalize(camvec);
@@ -368,12 +371,15 @@ bumpvariantshader = [
             ])
         }
     ] [
+        @glsl_hsv
+
         @(if (btopt "A") [result [
             @(gfetchdefs [refractlight refractmask])
             uniform vec4 refractparams;
             uniform float refractdepth;
         ]])
         uniform vec4 colorparams;
+        uniform vec4 hsv;
         uniform sampler2D diffusemap, normalmap;
         @(? (|| $msaalight [&& $msaasamples [! (btopt "a")]]) [uniform float hashid;])
         varying mat3 world;
@@ -458,7 +464,7 @@ bumpvariantshader = [
                 vec3 bumpw = normalize(world * bump);
             ]])
 
-            gcolor.rgb = diffuse.rgb*colorparams.rgb;
+            gcolor.rgb = applyHSV(diffuse.rgb*colorparams.rgb, hsv.rgb);
 
             @(if (btopt "r") [result [
                 float invfresnel = dot(camvecn, bumpw);
@@ -654,6 +660,7 @@ shadowmapworldvariantshader = [
         }
     ] [
         uniform vec4 colorparams;
+        uniform vec4 hsv;
         uniform sampler2D diffusemap;
         varying vec2 texcoord0;
 
@@ -662,6 +669,8 @@ shadowmapworldvariantshader = [
         ])
 
         fragdata(0) vec4 gcolor;
+
+        @glsl_hsv
 
         void main(void)
         {
@@ -684,7 +693,7 @@ shadowmapworldvariantshader = [
                 #define mask 1.0
             ]])
 
-            gcolor.rgb = mix(vec3(1.0), diffuse.rgb*colorparams.rgb, alpha) * (1.0 - mask);
+            gcolor.rgb = mix(vec3(1.0), applyHSV(diffuse.rgb*colorparams.rgb, hsv.rgb), alpha) * (1.0 - mask);
             gcolor.a = alpha;
         }
     ]
@@ -726,7 +735,10 @@ defershader 1 "rsmworld" [
             normal = vec4(vnormal, dot(vnormal, rsmdir));
         }
     ] [
+        @glsl_hsv
+
         uniform vec4 colorparams;
+        uniform vec4 hsv;
         uniform sampler2D diffusemap;
         varying vec4 normal;
         varying vec2 texcoord0;
@@ -747,7 +759,7 @@ defershader 1 "rsmworld" [
                 #define alpha colorparams.a
             ]])
 
-            gcolor.rgb = normal.w*diffuse.rgb*colorparams.rgb;
+            gcolor.rgb = applyHSV(normal.w*diffuse.rgb*colorparams.rgb, hsv.rgb);
             gnormal = vec4(normal.xyz*0.5+0.5, 0.0);
 
             @(if (= $i 1) [result [

--- a/config/glsl/world.cfg
+++ b/config/glsl/world.cfg
@@ -250,6 +250,8 @@ worldshader "envspecworld" "esr"
 worldshader "envspecmapworld" "esSrR"
 worldshader "envglowworld" "erg"
 worldshader "envpulseglowworld" "ergG"
+worldshader "envspecglowworld" "esrg"
+worldshader "envspecmapglowworld" "esSrRg"
 
 worldshader "triplanarworld" "T"
 worldshader "triplanardetailworld" "Td"

--- a/config/glsl/world.cfg
+++ b/config/glsl/world.cfg
@@ -64,6 +64,7 @@ worldvariantshader = [
         attribute vec2 vtexcoord0;
         uniform mat4 camprojmatrix;
         uniform vec2 texgenscroll;
+        uniform vec4 transform;
         varying vec3 nvec;
         @(ginterpvert (|| $msaalight [&& $msaasamples [! (wtopt "a")]]))
         @(if (wtopt "T") [result [
@@ -84,11 +85,11 @@ worldvariantshader = [
         {
             gl_Position = camprojmatrix * vvertex;
             @(if (wtopt "T") [result [
-                texcoordx = vec2(vvertex.y, -vvertex.z) * texgenscale;
-                texcoordy = vec2(vvertex.x, -vvertex.z) * texgenscale;
-                texcoordz = vvertex.xy * @(? (wtopt "d") "detailscale" "texgenscale");
+                texcoordx = mat2(transform) * (vec2(vvertex.y, -vvertex.z) * texgenscale);
+                texcoordy = mat2(transform) * (vec2(vvertex.x, -vvertex.z) * texgenscale);
+                texcoordz = mat2(transform) * (vvertex.xy * @(? (wtopt "d") "detailscale" "texgenscale"));
             ]] [result [
-                texcoord0 = vtexcoord0 + texgenscroll;
+                texcoord0 = mat2(transform) * (vtexcoord0 + texgenscroll);
             ]])
             @(? (wtopt "b") [
                 texcoord1 = (vvertex.xy - blendmapparams.xy)*blendmapparams.zw;
@@ -314,6 +315,7 @@ bumpvariantshader = [
         attribute vec2 vtexcoord0;
         uniform mat4 camprojmatrix;
         uniform vec2 texgenscroll;
+        uniform vec4 transform;
         @(ginterpvert (|| $msaalight [&& $msaasamples [! (btopt "a")]] [btopt "A"]))
         @(if (btopt "T") [result [
             uniform vec2 texgenscale;
@@ -342,16 +344,16 @@ bumpvariantshader = [
             @(gdepthpackvert (|| $msaalight [&& $msaasamples [! (btopt "a")]] [btopt "A"]))
 
             @(if (btopt "T") [result [
-                texcoordx = vec2(vvertex.y, -vvertex.z) * texgenscale;
-                texcoordy = vec2(vvertex.x, -vvertex.z) * texgenscale;
-                texcoordz = vvertex.xy * @(? (btopt "d") "detailscale" "texgenscale");
+                texcoordx = mat2(transform) * (vec2(vvertex.y, -vvertex.z) * texgenscale);
+                texcoordy = mat2(transform) * (vec2(vvertex.x, -vvertex.z) * texgenscale);
+                texcoordz = mat2(transform) * (vvertex.xy * @(? (btopt "d") "detailscale" "texgenscale"));
 
                 normal = vnormal;
                 tangentx = normalize(vec3(1.001, 0.0, 0.0) - vnormal*vnormal.x);
                 tangenty = normalize(vec3(0.0, 1.001, 0.0) - vnormal*vnormal.y);
                 tangentz = normalize(vec3(0.0, 0.0, -1.001) + vnormal*vnormal.z);
             ]] [result [
-                texcoord0 = vtexcoord0 + texgenscroll;                
+                texcoord0 = mat2(transform) * (vtexcoord0 + texgenscroll);                
 
                 vec3 bitangent = cross(vnormal, vtangent.xyz) * vtangent.w;
                 // calculate tangent -> world transform

--- a/config/stdedit.cfg
+++ b/config/stdedit.cfg
@@ -361,3 +361,91 @@ setsundir = [
 	sunlightpitch $arg2
 ]
 getsundir = [ sunlightyaw ; sunlightpitch ]
+
+
+
+
+///////////////////////////////////////////////////////////////////////////////
+//  Texture linear transformations via `vmatrix`                             //
+///////////////////////////////////////////////////////////////////////////////
+
+// RESET:
+// use `/vmatrix` without arguments to reset the transformations.
+//
+// ROTATE by an angle:
+// `/vmatrix rotate 30`
+// rotation often results in a texture that does not align well with the
+// geometry around it. In this case try one of the following:
+// `/vmatrix rotscale1 30`
+// `/vmatrix rotscale2 30`
+// these apply a scale factor that is more likely to result in an aligned
+// texture.
+//
+// SHEAR:
+// shear transforms turn squares into parallelograms.
+// Shear transforms can be applied along one or both axes:
+// `/vmatrix shear 0.5 0`
+// `/vmatrix shear -0.5 0`
+// `/vmatrix shear 0 0.5`
+// `/vmatrix shear 0.5 -0.5`
+// values greater than 1 produce a strong deformation.
+// Most commonly, values that align well with geometry are
+// multiples of 1/8 (0.125).
+//
+// SCALE:
+// different scale factors can be applied to each axis individually:
+// `/vmatrix scale 2`
+// `/vmatrix scale 2 1`
+// `/vmatrix scale 1 2`
+// `/vmatrix scale 2 0.5`
+//
+// MANUAL TRANSFORMATIONS:               | 1 3 |
+// `/vmatrix 1 2 3 4` applies the matrix | 2 4 |
+vmatrix = [
+    do [ vrawmatrix @(.calcmatrix $getseltex $arg1 $arg2 $arg3 $arg4 $arg5) ]
+]
+texmatrix = [
+    do [ texrawmatrix @(.calcmatrix (- $numslots 1) $arg1 $arg2 $arg3 $arg4 $arg5) ]
+]
+getvmatrix = [
+    result (invert2x2 (getvrawmatrix $arg1))
+]
+.calcmatrix = [
+    local slot ar theta lambda mu s c s2 c2 sc
+    slot = $arg1
+    ar = (? (> $slot 0) (gettexaspectwh (+s "data/texture/world/" (gettexname $slot))) 1)
+    if (=s $arg2 "rotate") [
+        theta = (*f -1 $arg3)
+        result (sandwich2x2 $ar (concat (cos $theta) (sin $theta) (*f -1 (sin $theta)) (cos $theta)))
+    ] [
+        if (=s $arg2 "shear") [
+            lambda = $arg3
+            mu = (? $arg4 $arg4 0)
+            result (invert2x2 (sandwich2x2 $ar (concat (+f 1 (*f $lambda $mu)) $mu $lambda 1)))
+        ] [
+            if (=s $arg2 "scale") [
+                result (concat (divf 1 (? $arg3 $arg3 1)) 0 0 (divf 1 (? $arg4 $arg4 (? $arg3 $arg3 1))))
+            ] [
+                if (=s $arg2 "rotscale1") [
+                    theta = $arg3
+                    s = (sin $theta)
+                    c = (cos $theta); c2 = (*f $c $c)
+                    sc = (*f $s $c)
+
+                    result (invert2x2 (sandwich2x2 $ar (concat $c2 $sc (*f -1 $sc) $c2)))
+                ] [
+                    if (=s $arg2 "rotscale2") [
+                        theta = $arg3
+                        s = (sin $theta); s2 = (*f $s $s)
+                        c = (cos $theta)
+                        sc = (*f $s $c)
+
+                        result (invert2x2 (sandwich2x2 $ar (concat $sc $s2 (*f -1 $s2) $sc)))
+                    ] [
+                        result (invert2x2 (sandwich2x2 $ar (concat $arg2 $arg3 $arg4 $arg5)))
+                    ]
+                ]
+            ]
+        ]
+    ]
+]

--- a/config/stdlib.cfg
+++ b/config/stdlib.cfg
@@ -203,3 +203,40 @@ decalload = [
 		error [decalload error: @arg1.cfg not found]
 	]
 ]
+
+///////////////////////////////////////////////////////////////////////////////
+//  Matrix operations for `vmatrix`                                          //
+///////////////////////////////////////////////////////////////////////////////
+det2x2 = [
+    (-f (*f $arg1 $arg4) (*f $arg3 $arg2))
+]
+invert2x2 = [
+    local k det
+    det = (det2x2 (at $arg1 0) (at $arg1 1) (at $arg1 2) (at $arg1 3))
+    if (=f $det 0) [
+        result [1 0 0 1]
+    ] [
+        k = (divf 1 $det)
+        result (concat (*f $k (at $arg1 3)) (*f $k (*f -1 (at $arg1 1))) (*f $k (*f -1 (at $arg1 2))) (*f $k (at $arg1 0)) )
+    ]
+]
+// makes transformations work when textures are not square
+sandwich2x2 = [
+    local s M A B
+    s = $arg1
+    M = $arg2
+    A = (concat $s 0 0 1)
+    B = (concat (divf 1 $s) 0 0 1)
+    result (multiply2x2 $B (multiply2x2 $M $A))
+]
+multiply2x2 = [
+    result (concat (
+        +f (*f (at $arg1 0) (at $arg2 0)) (*f (at $arg1 2) (at $arg2 1))
+    ) (
+        +f (*f (at $arg1 1) (at $arg2 0)) (*f (at $arg1 3) (at $arg2 1))
+    ) (
+        +f (*f (at $arg1 0) (at $arg2 2)) (*f (at $arg1 2) (at $arg2 3))
+    ) (
+        +f (*f (at $arg1 1) (at $arg2 2)) (*f (at $arg1 3) (at $arg2 3))
+    ) )
+]

--- a/source/engine/octaedit.cpp
+++ b/source/engine/octaedit.cpp
@@ -2388,15 +2388,15 @@ void vmaterial(int *n)
 COMMAND(vmaterial, "i");
 ICOMMAND(getvmaterial, "i", (int *tex), intret(lookupvslot(*tex, false).texturematerial));
 
-void vhue(float *_h, float *_s, float *_v)
+void vhue(float *_h, float *_s, float *_v, int *numargs)
 {
     if(noedit()) return;
     VSlot ds;
     ds.changed = 1<<VSLOT_HSV;
-    ds.hsv = vec(fmod(*_h, 360.0f), *_s, *_v);
+    ds.hsv = vec(fmod(*_h, 360.0f), (*numargs >= 2) ? *_s : 1, (*numargs >= 3) ? *_v : 1);
     mpeditvslot(usevdelta, ds, allfaces, sel, true);
 }
-COMMAND(vhue, "fff");
+COMMAND(vhue, "fffN");
 ICOMMAND(getvhue, "i", (int *tex),
 {
     VSlot &vslot = lookupvslot(*tex, false);

--- a/source/engine/octaedit.cpp
+++ b/source/engine/octaedit.cpp
@@ -2388,6 +2388,22 @@ void vmaterial(int *n)
 COMMAND(vmaterial, "i");
 ICOMMAND(getvmaterial, "i", (int *tex), intret(lookupvslot(*tex, false).texturematerial));
 
+void vhue(float *_h, float *_s, float *_v)
+{
+    if(noedit()) return;
+    VSlot ds;
+    ds.changed = 1<<VSLOT_HSV;
+    ds.hsv = vec(fmod(*_h, 360.0f), *_s, *_v);
+    mpeditvslot(usevdelta, ds, allfaces, sel, true);
+}
+COMMAND(vhue, "fff");
+ICOMMAND(getvhue, "i", (int *tex),
+{
+    VSlot &vslot = lookupvslot(*tex, false);
+    defformatstring(str, "%s %s %s", floatstr(vslot.hsv.r), floatstr(vslot.hsv.g), floatstr(vslot.hsv.b));
+    result(str);
+});
+
 void vreset()
 {
     if(noedit()) return;

--- a/source/engine/octaedit.cpp
+++ b/source/engine/octaedit.cpp
@@ -2404,6 +2404,22 @@ ICOMMAND(getvhue, "i", (int *tex),
     result(str);
 });
 
+void vrawmatrix(float *x, float *y, float *z, float *w)
+{
+    if(noedit()) return;
+    VSlot ds;
+    ds.changed = 1<<VSLOT_MATRIX;
+    ds.transform = vec4(*x, *y, *z, *w);
+    mpeditvslot(usevdelta, ds, allfaces, sel, true);
+}
+COMMAND(vrawmatrix, "ffff");
+ICOMMAND(getvrawmatrix, "i", (int *tex),
+{
+    VSlot &vslot = lookupvslot(*tex, false);
+    defformatstring(str, "%s %s %s %s", floatstr(vslot.transform.x), floatstr(vslot.transform.y), floatstr(vslot.transform.z), floatstr(vslot.transform.w));
+    result(str);
+});
+
 void vreset()
 {
     if(noedit()) return;

--- a/source/engine/renderva.cpp
+++ b/source/engine/renderva.cpp
@@ -1151,6 +1151,7 @@ struct renderstate
     GLuint vbuf;
     bool vattribs, vquery;
     vec colorscale, hsv;
+    vec4 transform;
     float alphascale;
     float refractscale;
     vec refractcolor;
@@ -1163,7 +1164,7 @@ struct renderstate
     vec2 texgenscroll;
     int texgenorient, texgenmillis;
 
-    renderstate() : colormask(true), depthmask(true), alphaing(0), vbuf(0), vattribs(false), vquery(false), colorscale(1, 1, 1), hsv(0, 1, 1), alphascale(0), refractscale(0), refractcolor(1, 1, 1), blend(false), blendx(-1), blendy(-1), globals(-1), tmu(-1), slot(NULL), texgenslot(NULL), vslot(NULL), texgenvslot(NULL), texgenscroll(0, 0), texgenorient(-1), texgenmillis(lastmillis)
+    renderstate() : colormask(true), depthmask(true), alphaing(0), vbuf(0), vattribs(false), vquery(false), colorscale(1, 1, 1), hsv(0, 1, 1), transform(1, 0, 0, 1), alphascale(0), refractscale(0), refractcolor(1, 1, 1), blend(false), blendx(-1), blendy(-1), globals(-1), tmu(-1), slot(NULL), texgenslot(NULL), vslot(NULL), texgenvslot(NULL), texgenscroll(0, 0), texgenorient(-1), texgenmillis(lastmillis)
     {
         loopk(7) textures[k] = 0;
     }
@@ -1482,6 +1483,11 @@ static void changeslottmus(renderstate &cur, int pass, Slot &slot, VSlot &vslot)
         cur.hsv = vslot.hsv;
         GLOBALPARAMF(hsv, vslot.hsv.x, vslot.hsv.y, vslot.hsv.z, 1);
     }
+    if(cur.transform != vslot.transform)
+    {
+        cur.transform = vslot.transform;
+        GLOBALPARAMF(transform, vslot.transform.x, vslot.transform.y, vslot.transform.z, vslot.transform.w);
+    }
 
     loopvj(slot.sts)
     {
@@ -1766,6 +1772,7 @@ void setupgeom(renderstate &cur)
     glActiveTexture_(GL_TEXTURE0);
     GLOBALPARAMF(colorparams, 1, 1, 1, 1);
     GLOBALPARAMF(hsv, 0, 1, 1);
+    GLOBALPARAMF(transform, 1, 0, 0, 1);
     GLOBALPARAMF(blendlayer, 1.0f);
 }
 

--- a/source/engine/renderva.cpp
+++ b/source/engine/renderva.cpp
@@ -1150,7 +1150,7 @@ struct renderstate
     bool shadowing;
     GLuint vbuf;
     bool vattribs, vquery;
-    vec colorscale;
+    vec colorscale, hsv;
     float alphascale;
     float refractscale;
     vec refractcolor;
@@ -1163,7 +1163,7 @@ struct renderstate
     vec2 texgenscroll;
     int texgenorient, texgenmillis;
 
-    renderstate() : colormask(true), depthmask(true), alphaing(0), vbuf(0), vattribs(false), vquery(false), colorscale(1, 1, 1), alphascale(0), refractscale(0), refractcolor(1, 1, 1), blend(false), blendx(-1), blendy(-1), globals(-1), tmu(-1), slot(NULL), texgenslot(NULL), vslot(NULL), texgenvslot(NULL), texgenscroll(0, 0), texgenorient(-1), texgenmillis(lastmillis)
+    renderstate() : colormask(true), depthmask(true), alphaing(0), vbuf(0), vattribs(false), vquery(false), colorscale(1, 1, 1), hsv(0, 1, 1), alphascale(0), refractscale(0), refractcolor(1, 1, 1), blend(false), blendx(-1), blendy(-1), globals(-1), tmu(-1), slot(NULL), texgenslot(NULL), vslot(NULL), texgenvslot(NULL), texgenscroll(0, 0), texgenorient(-1), texgenmillis(lastmillis)
     {
         loopk(7) textures[k] = 0;
     }
@@ -1477,6 +1477,12 @@ static void changeslottmus(renderstate &cur, int pass, Slot &slot, VSlot &vslot)
         GLOBALPARAMF(colorparams, vslot.colorscale.x, vslot.colorscale.y, vslot.colorscale.z, 1);
     }
 
+    if(cur.hsv != vslot.hsv)
+    {
+        cur.hsv = vslot.hsv;
+        GLOBALPARAMF(hsv, vslot.hsv.x, vslot.hsv.y, vslot.hsv.z, 1);
+    }
+
     loopvj(slot.sts)
     {
         Slot::Tex &t = slot.sts[j];
@@ -1759,6 +1765,7 @@ void setupgeom(renderstate &cur)
 {
     glActiveTexture_(GL_TEXTURE0);
     GLOBALPARAMF(colorparams, 1, 1, 1, 1);
+    GLOBALPARAMF(hsv, 0, 1, 1);
     GLOBALPARAMF(blendlayer, 1.0f);
 }
 

--- a/source/engine/texture.h
+++ b/source/engine/texture.h
@@ -614,6 +614,7 @@ enum
     VSLOT_DETAIL,
     VSLOT_MATERIAL,
     VSLOT_HSV,
+    VSLOT_MATRIX,
     VSLOT_NUM
 };
 
@@ -636,6 +637,7 @@ struct VSlot
     vec refractcolor;
     int texturematerial;
     vec hsv;
+    vec4 transform;
 
     VSlot(Slot *slot = NULL, int index = -1) : slot(slot), next(NULL), index(index), changed(0)
     {
@@ -662,6 +664,7 @@ struct VSlot
         refractcolor = vec(1, 1, 1);
         texturematerial = 0;
         hsv = vec(0, 1, 1);
+        transform = vec4(1, 0, 0, 1);
     }
 
     void cleanup()

--- a/source/engine/texture.h
+++ b/source/engine/texture.h
@@ -613,6 +613,7 @@ enum
     VSLOT_REFRACT,
     VSLOT_DETAIL,
     VSLOT_MATERIAL,
+    VSLOT_HSV,
     VSLOT_NUM
 };
 
@@ -634,6 +635,7 @@ struct VSlot
     float refractscale;
     vec refractcolor;
     int texturematerial;
+    vec hsv;
 
     VSlot(Slot *slot = NULL, int index = -1) : slot(slot), next(NULL), index(index), changed(0)
     {
@@ -659,6 +661,7 @@ struct VSlot
         refractscale = 0;
         refractcolor = vec(1, 1, 1);
         texturematerial = 0;
+        hsv = vec(0, 1, 1);
     }
 
     void cleanup()

--- a/source/engine/ui.cpp
+++ b/source/engine/ui.cpp
@@ -3118,6 +3118,7 @@ namespace UI
             changedraw(CHANGE_SHADER | CHANGE_COLOR);
 
             SETSHADER(hudrgb);
+            LOCALPARAMF(previewhsv, vslot.hsv.x, vslot.hsv.y, vslot.hsv.z);
             vec2 tc[4] = { vec2(0, 0), vec2(1, 0), vec2(1, 1), vec2(0, 1) };
             int xoff = vslot.offset.x, yoff = vslot.offset.y;
             if(vslot.rotation)
@@ -3149,6 +3150,7 @@ namespace UI
             if(layertex)
             {
                 glBindTexture(GL_TEXTURE_2D, layertex->id);
+                LOCALPARAMF(previewhsv, layer->hsv.x, layer->hsv.y, layer->hsv.z);
                 gle::color(layer->colorscale);
                 quad(x, y, w/2, h/2, tc);
             }

--- a/source/engine/ui.cpp
+++ b/source/engine/ui.cpp
@@ -3119,6 +3119,7 @@ namespace UI
 
             SETSHADER(hudrgb);
             LOCALPARAMF(previewhsv, vslot.hsv.x, vslot.hsv.y, vslot.hsv.z);
+            LOCALPARAMF(previewtransform, vslot.transform.x, vslot.transform.y, vslot.transform.z, vslot.transform.w);
             vec2 tc[4] = { vec2(0, 0), vec2(1, 0), vec2(1, 1), vec2(0, 1) };
             int xoff = vslot.offset.x, yoff = vslot.offset.y;
             if(vslot.rotation)
@@ -3151,6 +3152,7 @@ namespace UI
             {
                 glBindTexture(GL_TEXTURE_2D, layertex->id);
                 LOCALPARAMF(previewhsv, layer->hsv.x, layer->hsv.y, layer->hsv.z);
+                LOCALPARAMF(previewtransform, layer->transform.x, layer->transform.y, layer->transform.z, layer->transform.w);
                 gle::color(layer->colorscale);
                 quad(x, y, w/2, h/2, tc);
             }

--- a/source/engine/worldio.cpp
+++ b/source/engine/worldio.cpp
@@ -481,6 +481,10 @@ void savevslot(stream *f, VSlot &vs, int prev)
         loopk(3) f->putlil<float>(vs.refractcolor[k]);
     }
     if(vs.changed & (1<<VSLOT_DETAIL)) f->putlil<int>(vs.detail);
+    if(vs.changed & (1<<VSLOT_HSV))
+    {
+        loopk(3) f->putlil<float>(vs.hsv[k]);
+    }
 }
 
 void savevslots(stream *f, int numvslots)
@@ -558,6 +562,10 @@ void loadvslot(stream *f, VSlot &vs, int changed)
         loopk(3) vs.refractcolor[k] = f->getlil<float>();
     }
     if(vs.changed & (1<<VSLOT_DETAIL)) vs.detail = f->getlil<int>();
+    if(vs.changed & (1<<VSLOT_HSV))
+    {
+        loopk(3) vs.hsv[k] = f->getlil<float>();
+    }
 }
 
 void loadvslots(stream *f, int numvslots)

--- a/source/engine/worldio.cpp
+++ b/source/engine/worldio.cpp
@@ -485,6 +485,10 @@ void savevslot(stream *f, VSlot &vs, int prev)
     {
         loopk(3) f->putlil<float>(vs.hsv[k]);
     }
+    if(vs.changed & (1<<VSLOT_MATRIX))
+    {
+        loopk(4) f->putlil<float>(vs.transform[k]);
+    }
 }
 
 void savevslots(stream *f, int numvslots)
@@ -565,6 +569,10 @@ void loadvslot(stream *f, VSlot &vs, int changed)
     if(vs.changed & (1<<VSLOT_HSV))
     {
         loopk(3) vs.hsv[k] = f->getlil<float>();
+    }
+    if(vs.changed & (1<<VSLOT_MATRIX))
+    {
+        loopk(4) vs.transform[k] = f->getlil<float>();
     }
 }
 


### PR DESCRIPTION
- Adds the ability to apply hue, saturation and brightness adjustments to a texture via `/texhue` and `/vhue`, enabling effects that cannot be achieved with `/vcolor`
- Adds the ability to apply arbitrary linear transformations to a texture (e.g. rotation, scale, shear) via `/texmatrix` and `/vmatrix`