### PR TITLE
Don't persist variables defined in the default configs after calling `/reui`

### DIFF
--- a/config/ui.cfg
+++ b/config/ui.cfg
@@ -24,4 +24,4 @@ loopfiles f "config/ui/menus" cfg [
 //  Refresh Everything                                                       //
 ///////////////////////////////////////////////////////////////////////////////
 
-reui = [ exec "config/ui.cfg" ]
+reui = [ nopersist [ exec "config/ui.cfg" ] ]

--- a/source/engine/command.cpp
+++ b/source/engine/command.cpp
@@ -319,6 +319,12 @@ static void debugcodeline(const char *p, const char *fmt, ...)
 }
 
 ICOMMAND(nodebug, "e", (uint *body), { nodebug++; executeret(body, *commandret); nodebug--; });
+ICOMMAND(nopersist, "e", (uint *body), {
+    int oldflags = identflags;
+    identflags &= ~IDF_PERSIST;
+    executeret(body, *commandret);
+    identflags = oldflags;
+})
 
 void addident(ident *id)
 {


### PR DESCRIPTION
Adds the `nopersist` command which executes a block of cubescript code without persisting the variables declared inside of it