### PR TITLE
Fix radar icons

### DIFF
--- a/source/game/ctf.h
+++ b/source/game/ctf.h
@@ -890,7 +890,7 @@ ICOMMAND(flagstate, "i", (int *n),
     intret(ctfmode.flags[*n].owner ? 1 : (ctfmode.flags[*n].droptime ? (ctfmode.flags[*n].droploc.x < 0 ? 3 : 2) : 0));
 });
 ICOMMAND(flagdroploc, "i", (int *n), { result(ctfmode.flags.inrange(*n) ? tempformatstring("%f %f %f", ctfmode.flags[*n].droploc.x, ctfmode.flags[*n].droploc.y, ctfmode.flags[*n].droploc.z) : "0 0 0"); });
-ICOMMAND(flagowner, "i", (int *n), { intret(ctfmode.flags.inrange(*n) ? ctfmode.flags[*n].owner->clientnum : -1); });
+ICOMMAND(flagowner, "i", (int *n), { intret(ctfmode.flags.inrange(*n) ? ctfmode.flags[*n].owner ? ctfmode.flags[*n].owner->clientnum : -1 : -1); });
 
 #endif
 

--- a/source/game/gameclient.cpp
+++ b/source/game/gameclient.cpp
@@ -367,7 +367,7 @@ namespace game
     {
         gameent *d = getclient(cn);
         gameent *s = followingplayer(self);
-        if(!d || d->state == CS_SPECTATOR || (d != s && !isally(d, s))) return "0 0 0";
+        if(!d || d->state == CS_SPECTATOR || (d != s && !d->holdingflag && !isally(d, s))) return "0 0 0";
         return tempformatstring("%f %f %f", d->o.x, d->o.y, d->o.z);
     }
     ICOMMAND(getclientpos, "i", (int *cn), result(getclientpos(*cn)));


### PR DESCRIPTION
- fix a missing NULL check in the `flagowner` command
- allow getting the position of enemies who are holding the flag, so they can be shown on the radar