### PR TITLE
Add `-Wimplicit-fallthrough` compiler warning

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -1,5 +1,5 @@
 CXXFLAGS= -O3 -fomit-frame-pointer -ffast-math
-override CXXFLAGS+= -Wall -fsigned-char -fno-exceptions -fno-rtti
+override CXXFLAGS+= -Wall -Wimplicit-fallthrough -fsigned-char -fno-exceptions -fno-rtti
 
 PLATFORM= $(shell uname -s | tr '[:lower:]' '[:upper:]')
 PLATFORM_ARCH= $(shell uname -m)

--- a/source/engine/command.cpp
+++ b/source/engine/command.cpp
@@ -1758,6 +1758,7 @@ static void compilestatements(vector<uint> &code, const char *&p, int rettype, i
         {
             case '/':
                 if(p[2] != '/') break;
+                // fall through
             case ';': case ' ': case '\t': case '\r': case '\n': case '\0':
                 p++;
                 if(idname.str)
@@ -3245,6 +3246,7 @@ void writecfg(const char *name)
         case VAL_STR:
             if(!id.val.s[0]) break;
             if(!validateblock(id.val.s)) { f->printf("%s = %s\n", escapeid(id), escapestring(id.val.s)); break; }
+            // fall through
         case VAL_FLOAT:
         case VAL_INT:
             f->printf("%s = [%s]\n", escapeid(id), id.getstr()); break;

--- a/source/engine/texture.cpp
+++ b/source/engine/texture.cpp
@@ -579,10 +579,10 @@ void texmix(ImageData &s, int c1, int c2, int c3, int c4)
     readwritetex(d, s,
         switch(numchans)
         {
-            case 4: dst[3] = src[c4];
-            case 3: dst[2] = src[c3];
-            case 2: dst[1] = src[c2];
-            case 1: dst[0] = src[c1];
+            case 4: dst[3] = src[c4]; // fall through
+            case 3: dst[2] = src[c3]; // fall through
+            case 2: dst[1] = src[c2]; // fall through
+            case 1: dst[0] = src[c1]; // fall through
         }
     );
     s.replace(d);

--- a/source/engine/world.cpp
+++ b/source/engine/world.cpp
@@ -67,6 +67,7 @@ bool getentboundingbox(const extentity &e, ivec &o, ivec &r)
                 break;
             }
         // invisible mapmodels use entselradius
+        // fall through
         default:
             o = ivec(vec(e.o).sub(entselradius));
             r = ivec(vec(e.o).add(entselradius+1));
@@ -120,6 +121,7 @@ void modifyoctaentity(int flags, int id, extentity &e, cube *c, const ivec &cor,
                         break;
                     }
                     // invisible mapmodel
+                    // fall through
                 default:
                     oe.other.add(id);
                     break;
@@ -179,6 +181,7 @@ void modifyoctaentity(int flags, int id, extentity &e, cube *c, const ivec &cor,
                         break;
                     }
                     // invisible mapmodel
+                    // fall through
                 default:
                     oe.other.removeobj(id);
                     break;

--- a/source/game/ai.cpp
+++ b/source/game/ai.cpp
@@ -949,7 +949,7 @@ namespace ai
                 {
                     switch(wpspot(d, d->ai->route[n], true))
                     {
-                        case 2: d->ai->clear(false);
+                        case 2: d->ai->clear(false); // fall through
                         case 1: return true; // not close enough to pop it yet
                         case 0: default: break;
                     }

--- a/source/game/entity.cpp
+++ b/source/game/entity.cpp
@@ -130,7 +130,8 @@ namespace entities
                     if (e.attr2 > 0)
                     {
                         preloadmodel(mapmodelname(e.attr2));
-                    }      
+                    }
+                    break;      
                 case JUMPPAD:
                     if (e.attr4 > 0)
                     {
@@ -716,10 +717,12 @@ namespace entities
             case FLAG:
                 e.attr5 = e.attr4;
                 e.attr4 = e.attr3;
+                // fall through
             case TELEDEST:
                 e.attr3 = e.attr2;
                 e.attr2 = e.attr1;
                 e.attr1 = (int)self->yaw;
+                break;
              case TARGET:
                 e.attr2 = e.attr1;
                 break;

--- a/source/game/gameclient.cpp
+++ b/source/game/gameclient.cpp
@@ -2120,6 +2120,7 @@ namespace game
             {
                 int state = getint(p);
                 updateroundstate(state);
+                break;
             }
 
             case N_CURRENTMASTER:

--- a/source/game/gameserver.cpp
+++ b/source/game/gameserver.cpp
@@ -598,6 +598,7 @@ namespace server
                 case '!':
                     mode++;
                     if(mode[0] != '?') break;
+                    // fall through
                 case '?':
                     mode++;
                     loopk(NUMGAMEMODES) if(searchmodename(gamemodes[k].name, mode))

--- a/source/game/weapon.cpp
+++ b/source/game/weapon.cpp
@@ -311,6 +311,7 @@ namespace game
         {
             case BNC_GRENADE2:
                 bnc.collidetype = COLLIDE_ELLIPSE;
+                // fall through
             case BNC_GRENADE:
                 bnc.bouncesound = S_BOUNCE_GRENADE;
                 break;


### PR DESCRIPTION
Fixes client privilege getting reset due to a missing `break` statement