### PR TITLE
Keyboard and mouse input improvements for the UI

### DIFF
--- a/source/engine/console.cpp
+++ b/source/engine/console.cpp
@@ -529,8 +529,8 @@ void execbind(keym &k, bool isdown)
 
 void iskeyheld(char *key)
 {
-    keym* km = findbind(key);
-    intret(km->pressed ? 1 : 0);
+    const keym *km = findbind(key);
+    intret(km && km->pressed ? 1 : 0);
 }
 ICOMMAND(iskeyheld, "s", (char* key), iskeyheld(key));
 
@@ -555,6 +555,25 @@ bool consoleinput(const char *str, int len)
 
     return true;
 }
+
+// returns the contents of the clipboard
+void getclipboard()
+{
+    if(!SDL_HasClipboardText())
+    {
+        result("");
+        return;
+    }
+    char *cb = SDL_GetClipboardText();
+    if(!cb)
+    {
+        result("");
+        return;
+    }
+    stringret(newstring(cb, MAXSTRLEN));
+    SDL_free(cb);
+}
+COMMAND(getclipboard, "");
 
 void pasteconsole()
 {


### PR DESCRIPTION
Allows text and keybind input fields to be implemented in cubescript

- `uitext` now accepts a `cursor` argument: if present (even if negative), the label listens for clicks and sets the `uicursorindex` variable to the index of the clicked character
- if `cursor >= 0`, the label listens for keyboard input and sets `uikeycode` to the keycode of the pressed key. If `uisettextinput 1` was used, the `uitextinput` variable is set to the parsed input text.