### PR TITLE
Fix normals of textures transformed with `/vmatrix`

### DIFF
--- a/config/glsl/world.cfg
+++ b/config/glsl/world.cfg
@@ -387,6 +387,7 @@ bumpvariantshader = [
         ]])
         uniform vec4 colorparams;
         uniform vec4 hsv;
+        uniform vec4 transform;
         uniform sampler2D diffusemap, normalmap;
         @(? (|| $msaalight [&& $msaasamples [! (btopt "a")]]) [uniform float hashid;])
         varying mat3 world;
@@ -446,10 +447,10 @@ bumpvariantshader = [
                 vec3 bumpx = (texture2D(normalmap, dtcx).rgb*2.0 - 1.0)*triblend.x;
                 vec3 bumpy = (texture2D(normalmap, dtcy).rgb*2.0 - 1.0)*triblend.y;
                 vec3 bumpz = (texture2D(@(? (btopt "d") "detailnormalmap" "normalmap"), dtcz).rgb*2.0 - 1.0)*triblend.z;
-                vec3 bumpw = normalize(worldx*bumpx + worldy*bumpy + worldz*bumpz);
+                vec3 bumpw = mat3(mat2(transform.xzyw)) * normalize(worldx*bumpx + worldy*bumpy + worldz*bumpz);
 
                 @(? (btopt "A") [
-                    vec2 bump = bumpx.xy + bumpy.xy + bumpz.xy;
+                    vec2 bump = mat2(transform.xzyw) * (bumpx.xy + bumpy.xy + bumpz.xy);
                 ])
             ]] [result [
                 @(? (btopt "p") [
@@ -467,7 +468,7 @@ bumpvariantshader = [
                 ] [ 
                     vec3 bump = texture2D(normalmap, dtc).rgb;
                 ])
-                bump = bump*2.0 - 1.0;
+                bump = mat3(mat2(transform.xzyw)) * (bump*2.0 - 1.0);
                 vec3 bumpw = normalize(world * bump);
             ]])
 


### PR DESCRIPTION
Normals have to be multiplied by the inverse transpose of the transformation matrix