### PR TITLE
New event system for monsters

### DIFF
--- a/config/ui/hud/editstats.cfg
+++ b/config/ui/hud/editstats.cfg
@@ -233,7 +233,7 @@
                         uiHorSld ea1 -1 (- $nummapmodels 1) 1 [ entattr 1 $ea1 ]
                     ] "Model ID#"
                     uiEntCell "3" [
-                        uiHorSld ea2 1 500 1 [ entattr 2 $ea1 ]
+                        uiHorSld ea2 1 500 1 [ entattr 2 $ea2 ]
                     ] "Radius"
                     uiEntCell "4" [
                         uiHorSld ea3 1 500 1 [ entattr 3 $ea3 ]
@@ -248,16 +248,26 @@
                 ] "target" [
                     uialign -1
                     uiEntCell "1" [
-                        uiHorSld ea0 0 1000 10000 [ entattr 0 $ea0 ]
-                    ] "Actor ID#"
+                        uiOptionSldWrp ea0 [
+                            0 "Player"
+                            1 "Brute"
+                            2 "Gray"
+                            3 "Guard"
+                            4 "Mech"
+                            5 "Spider"
+                        ] [ entattr 0 $ea0 ]
+                    ] "Monster Type"
                     uiEntCell "2" [
                         uiHorSld ea1 0 360 1 [ entattr 1 $ea1 ]
                     ] "Yaw"
                     uiEntCell "3" [
-                        uiHorSld ea2 0 49 1 [ entattr 3 $ea0 ]
-                    ] "Trigger ID#"
+                        uiHorSld ea2 0 49 1 [ entattr 2 $ea2 ]
+                    ] "(Unused)"
                     uiEntCell "4" [
-                        uiHorSld ea3 0 1 1 [ entattr 4 $ea1 ]
+                        uiOptionSldWrp ea3 [
+                            0 "No"
+                            1 "Yes"
+                        ] [ entattr 3 $ea3 ]
                     ] "Active"
                 ]
             ] [

--- a/source/Makefile
+++ b/source/Makefile
@@ -518,7 +518,8 @@ game/monster.o: game/game.h shared/cube.h shared/tools.h shared/geom.h
 game/monster.o: shared/ents.h shared/command.h shared/glexts.h shared/glemu.h
 game/monster.o: engine/sound.h shared/iengine.h shared/igame.h
 game/monster.o: game/projectile.h game/weapon.h game/ai.h game/gamemode.h
-game/monster.o: game/entity.h game/announcer.h game/monster.h
+game/monster.o: game/entity.h game/announcer.h game/monster.h game/event.h
+game/monster.o: game/query.h
 game/weapon.o: game/game.h shared/cube.h shared/tools.h shared/geom.h
 game/weapon.o: shared/ents.h shared/command.h shared/glexts.h shared/glemu.h
 game/weapon.o: engine/sound.h shared/iengine.h shared/igame.h

--- a/source/game/event.h
+++ b/source/game/event.h
@@ -18,10 +18,16 @@ namespace game
             Use = 0,      // fires when the player is close and presses the "Use" button
             Proximity,    // fires when the player is close
             Distance,     // fires when the player was close and moves away or dies
+
+            Notice,       // a monster noticed the player
+            Pain,         // a monster took damage
+            Death,        // a monster died
+
             Manual,       // can only be fired manually with the `emittriggerevent` command
             NUMEVENTTYPES
         };
 
+        template<class T> void emit(T* source, Type event);
         template<Emitter t> void emit(const int id, const Type event);
 
         void onMapStart();

--- a/source/game/game.h
+++ b/source/game/game.h
@@ -662,6 +662,7 @@ struct teaminfo
 namespace entities
 {
     extern void preloadEntities();
+    extern void renderentities();
     extern void preloadWorld();
     extern void checkitems(gameent *d);
     extern void updatepowerups(int time, gameent *d);
@@ -921,7 +922,39 @@ namespace game
     extern vector<hitmsg> hits;
 
     // monster.cpp
-    struct monster;
+    struct monster : gameent
+    {
+        int monsterstate; // one of MS_*, MS_NONE means it's not an NPC
+
+        int mtype; // see monstertypes table
+        gameent *enemy; // monster wants to kill this entity
+        float targetyaw; // monster wants to look in this direction
+        int trigger; // millis at which transition to another monsterstate takes place
+        vec attacktarget;
+        int anger; // how many times already hit by fellow monster
+        physent *stacked;
+        vec stackpos, orient;
+        bool halted, canmove, exploding;
+        int lastunblocked, detonating;
+        int bursting, shots;
+
+        int id;
+        char *label;
+
+        monster(int _type, int _yaw, int _canmove, int _state, int _trigger, int _move, const char *_label);
+        ~monster();
+        void normalize_yaw(float angle);
+        void transition(int _state, int _moving, int n, int r);
+        void burst(bool on);
+        void emitattacksound();
+        void alert(bool on);
+        void monsteraction(int curtime);
+        void preparedetonation();
+        void detonate();
+        void monsterdeath(int forcestate = -1, int atk = ATK_INVALID, int flags = 0);
+        void heal();
+        void monsterpain(int damage, gameent *d, int atk, int flags);
+    };
     extern vector<monster *> monsters;
 
     extern void clearmonsters();
@@ -932,7 +965,7 @@ namespace game
     extern void suicidemonster(monster *m);
     extern void healmonsters();
     extern void hitmonster(int damage, monster *m, gameent *at, int atk, const vec& velocity, int flags = 0);
-    extern void monsterkilled(gameent* monster, int id, int flags = 0);
+    extern void monsterkilled(gameent* monster, int flags = 0);
     extern void checkmonsterinfight(monster *that, gameent *enemy);
     extern void endsp(bool allkilled);
     extern void spsummary(int accuracy);


### PR DESCRIPTION
Monsters emit events when they notice the player, take damage or die.

Event handlers can be defined for monsters with the `monster` command:
```
monster "my_query" "death" [
  // ... code to run when a monster matching the query dies
  // `eventsource` contains the ID of the monster that emitted the event
]
```

Monsters inherit the label from the entity they spawn from. Each monster has a unique ID.

New commands: `monsteremit` and `monsterquery`. They work similarly to `triggeremit` and `entquery`.