### PR TITLE
Write ent activity state to disk

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -127,7 +127,8 @@ CLIENT_OBJS= \
 	game/announcer.o \
 	game/camera.o \
 	game/event.o \
-	game/query.o
+	game/query.o \
+	game/worlddata.o
 
 CLIENT_PCH= shared/cube.h.gch engine/engine.h.gch game/game.h.gch
 
@@ -565,6 +566,12 @@ game/event.o: game/entity.h game/announcer.h game/monster.h game/query.h
 game/query.o: game/query.h shared/cube.h shared/tools.h shared/geom.h
 game/query.o: shared/ents.h shared/command.h shared/glexts.h shared/glemu.h
 game/query.o: engine/sound.h shared/iengine.h shared/igame.h
+game/worlddata.o: game/game.h shared/cube.h shared/tools.h shared/geom.h
+game/worlddata.o: shared/ents.h shared/command.h shared/glexts.h
+game/worlddata.o: shared/glemu.h engine/sound.h shared/iengine.h
+game/worlddata.o: shared/igame.h game/projectile.h game/weapon.h game/ai.h
+game/worlddata.o: game/gamemode.h game/entity.h game/announcer.h
+game/worlddata.o: game/monster.h
 
 shared/cube.h.gch: shared/tools.h shared/geom.h shared/ents.h
 shared/cube.h.gch: shared/command.h shared/glexts.h shared/glemu.h

--- a/source/engine/worldio.cpp
+++ b/source/engine/worldio.cpp
@@ -686,8 +686,8 @@ bool save_world(const char *mname, bool nolms)
     f->putchar((int)strlen(game::gameident()));
     f->write(game::gameident(), (int)strlen(game::gameident())+1);
     f->putlil<ushort>(entities::getExtraInfoSize());
-    vector<char> extras;
-    game::writegamedata(extras);
+    vector<uchar> extras;
+    game::writeGameData(extras, nolms);
     f->putlil<ushort>(extras.length());
     f->write(extras.getbuf(), extras.length());
 
@@ -840,9 +840,9 @@ bool load_world(const char *mname, const char *cname)        // still supports a
     }
     int eif = f->getlil<ushort>();
     int extrasize = f->getlil<ushort>();
-    vector<char> extras;
+    vector<uchar> extras;
     f->read(extras.pad(extrasize), extrasize);
-    if(samegame) game::readgamedata(extras);
+    if(samegame) game::readGameData(extras);
 
     texmru.shrink(0);
     ushort nummru = f->getlil<ushort>();

--- a/source/game/event.cpp
+++ b/source/game/event.cpp
@@ -103,9 +103,6 @@ namespace game
 
         VAR(eventsource, 0, 0, -1); // the id of the object that emitted the event
 
-        // emitters must be explicitly defined for each emitter type
-        template<class T> void emit(T*, Type)    = delete; // for structs that contain an `id` field
-        template<Emitter t> void emit(int, Type) = delete; // for `extentity`'s
         
         // event emitter for triggers
         template<>

--- a/source/game/event.h
+++ b/source/game/event.h
@@ -27,8 +27,9 @@ namespace game
             NUMEVENTTYPES
         };
 
-        template<class T> void emit(T* source, Type event);
-        template<Emitter t> void emit(const int id, const Type event);
+        // emitters must be explicitly defined for each emitter type
+        template<class T> void emit(T* source, Type event); // for structs that contain an `id` field
+        template<Emitter t> void emit(const int id, const Type event); // for `extentity`'s
 
         void onMapStart();
         void onPlayerDeath(const gameent* d, const gameent* actor);

--- a/source/game/game.cpp
+++ b/source/game/game.cpp
@@ -1111,6 +1111,7 @@ namespace game
         if(!m_mp(gamemode)) spawnplayer(self);
         else findplayerspawn(self, -1, m_teammode ? self->team : 0);
         entities::resetSpawn();
+        postWorldLoad();
         copystring(clientmap, name ? name : "");
 
         sendmapinfo();
@@ -1385,10 +1386,6 @@ namespace game
                 result(tempformatstring("%d:%02d", mins, secs));
             }
         }));
-
-    // any data written into this vector will get saved with the map data. Must take care to do own versioning, and endianess if applicable. Will not get called when loading maps from other games, so provide defaults.
-    void writegamedata(vector<char> &extras) {}
-    void readgamedata(vector<char> &extras) {}
 
     const char *gameconfig() { return "config/game.cfg"; }
     const char *savedconfig() { return "config/saved.cfg"; }

--- a/source/game/game.h
+++ b/source/game/game.h
@@ -1037,6 +1037,9 @@ namespace game
     extern void addscreenflash(const int amount);
     extern void checkentity(int type);
 
+    // worlddata.cpp
+    extern void postWorldLoad();
+
     extern int lowhealthscreen;
 
     namespace camera

--- a/source/game/worlddata.cpp
+++ b/source/game/worlddata.cpp
@@ -1,0 +1,116 @@
+#include "game.h"
+
+// game-specific data stored in the `extras` field of map files
+
+namespace game
+{
+    enum WorldDataTag
+    {
+        Invalid = -1,
+        DisabledEnts = 0,
+        NUMDATATAGS
+    };
+    static inline WorldDataTag dataTag(int t)
+    {
+        return t <= Invalid || t >= NUMDATATAGS ? Invalid : (WorldDataTag)t;
+    }
+
+    static vector<int> ents_to_disable;
+
+    static void writeDisabledEnts(vector<uchar>& block, bool nolms)
+    {
+        vector<int> disabled_ents;
+        const auto& ents = entities::getents();
+        int skip = 0;
+        // find disabled ents
+        loopv(ents)
+        {
+            if(!nolms && ents[i]->type == ET_EMPTY)
+            {
+                ++skip;
+                continue;
+            }
+            if(!ents[i]->isactive()) disabled_ents.add(i - skip);
+        }
+        // write ent id's to the buffer
+        if(const int count = disabled_ents.length())
+        {
+            putint(block, count);
+            loopv(disabled_ents)
+            {
+                putint(block, disabled_ents[i]);
+            }
+        }
+    }
+
+    // any data written into this vector will get saved with the map data. Must take care to do own versioning, and endianess if applicable. Will not get called when loading maps from other games, so provide defaults.
+    void writeGameData(vector<uchar> &extras, bool nolms)
+    {
+        // write DisabledEnts block
+        vector<uchar> disabledEntsBlock;
+        writeDisabledEnts(disabledEntsBlock, nolms);
+        if(const int len = disabledEntsBlock.length())
+        {
+            putint(extras, DisabledEnts);
+            putint(extras, len);
+            extras.put(disabledEntsBlock.buf, len);
+        }
+    }
+
+    static void readDisabledEnts(ucharbuf& block)
+    {
+        ents_to_disable.setsize(0);
+        const int count = getint(block);
+        loopi(count)
+        {
+            ents_to_disable.add(getint(block));
+        }
+    }
+
+    static void readBlock(WorldDataTag tag, ucharbuf& block)
+    {
+        switch(tag)
+        {
+            case DisabledEnts:
+                readDisabledEnts(block);
+                return;
+            case Invalid:
+                conoutf(CON_WARN, "Invalid data block: %d", (int)tag);
+                // fall through
+            default: return;
+        }
+    }
+
+    void readGameData(vector<uchar> &extras)
+    {
+        const int totallen = extras.length();
+        if(!totallen) return;
+        ucharbuf buf(extras.buf, totallen);
+        while(buf.remaining())
+        {
+            // read each block
+            const WorldDataTag tag = dataTag(getint(buf));
+            const int blocklen = getint(buf);
+
+            uchar* vblock = new uchar[blocklen];
+            ucharbuf block(vblock, blocklen);
+            buf.get(vblock, blocklen);
+
+            readBlock(tag, block);
+            delete[] vblock;
+        }
+    }
+
+    // called after the map has been loaded
+    void postWorldLoad()
+    {
+        const auto& ents = entities::getents();
+        loopv(ents_to_disable)
+        {
+            const int id = ents_to_disable[i];
+            if(!ents.inrange(id)) continue;
+            ents[id]->setactivity(false);
+        }
+        ents_to_disable.setsize(0);
+    }
+} // namespace game

--- a/source/shared/igame.h
+++ b/source/shared/igame.h
@@ -103,8 +103,8 @@ namespace game
     extern void renderavatar();
     extern void renderplayerpreview(int model, int color, int team, int weap);
     extern void findanims(const char *pattern, vector<int> &anims);
-    extern void writegamedata(vector<char> &extras);
-    extern void readgamedata(vector<char> &extras);
+    extern void writeGameData(vector<uchar> &extras, bool nolms);
+    extern void readGameData(vector<uchar> &extras);
     extern void trackparticles(physent *owner, vec &o, vec &d);
     extern void trackdynamiclights(physent *owner, vec &o, vec &hud);
     extern void voicecom(const int sound, char *text, const bool team);

--- a/source/vcpp/valhalla.vcxproj
+++ b/source/vcpp/valhalla.vcxproj
@@ -990,6 +990,7 @@
     <ClCompile Include="..\game\monster.cpp" />
     <ClCompile Include="..\game\projectile.cpp" />
     <ClCompile Include="..\game\query.cpp" />
+    <ClCompile Include="..\game\worlddata.cpp" />
     <ClCompile Include="..\shared\crypto.cpp" />
     <ClCompile Include="..\shared\geom.cpp" />
     <ClCompile Include="..\shared\glemu.cpp" />

--- a/source/vcpp/valhalla.vcxproj.filters
+++ b/source/vcpp/valhalla.vcxproj.filters
@@ -187,6 +187,9 @@
     <ClCompile Include="..\game\query.cpp">
       <Filter>Source\game</Filter>
     </ClCompile>
+    <ClCompile Include="..\game\worlddata.cpp">
+      <Filter>Source\game</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\game\ai.h">


### PR DESCRIPTION
A list of disabled entities is written to map files, allowing entities to be disabled at map load.

This data is stored in the `extras` field of map files.
The `extras` field, previously unused, now stores data as an array of "blocks", composed of:
- int tag
- int size
- uchar[] data

Where `tag` specifies the type of data contained in the block.

Drive-by: fix compilation on clang